### PR TITLE
Update samsung_ac.cpp to compile with the ESP-IDF framework

### DIFF
--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -67,7 +67,7 @@ namespace esphome
     {
       if (find_device(device->address) != nullptr)
       {
-        ESP_LOGW(TAG, "There is already and device for address %s registered.", device->address);
+        ESP_LOGW(TAG, "There is already and device for address %s registered.", device->address.c_str());
         return;
       }
 


### PR DESCRIPTION
This PR solves this issue when using the ESP-IDF framework:

```
In file included from src/esphome/components/samsung_ac/samsung_ac.cpp:1:
src/esphome/components/samsung_ac/samsung_ac.cpp: In member function 'void esphome::samsung_ac::Samsung_AC::register_device(esphome::samsung_ac::Samsung_AC_Device*)':
src/esphome/components/samsung_ac/samsung_ac.cpp:70:23: error: format '%s' expects argument of type 'char*', but argument 5 has type 'std::__cxx11::string' {aka 'std::__cxx11::basic_string<char>'} [-Werror=format=]
         ESP_LOGW(TAG, "There is already and device for address %s registered.", device->address);
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/core/log.h:72:36: note: in definition of macro 'ESPHOME_LOG_FORMAT'
 #define ESPHOME_LOG_FORMAT(format) format
                                    ^~~~~~
src/esphome/core/log.h:150:28: note: in expansion of macro 'esph_log_w'
 #define ESP_LOGW(tag, ...) esph_log_w(tag, __VA_ARGS__)
                            ^~~~~~~~~~
src/esphome/components/samsung_ac/samsung_ac.cpp:70:9: note: in expansion of macro 'ESP_LOGW'
         ESP_LOGW(TAG, "There is already and device for address %s registered.", device->address);
         ^~~~~~~~
cc1plus: some warnings being treated as errors
*** [.pioenvs/hvac-test/src/esphome/components/samsung_ac/samsung_ac.o] Error 1
========================= [FAILED] Took 20.23 seconds =========================
```