### PR TITLE
Update protocol_nasa.cpp to make it compile with ESP-IDF

### DIFF
--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -502,6 +502,8 @@ namespace esphome
                 target->set_fanmode(source, fan_mode_real_to_fanmode(message.value));
                 return;
             }
+            default:
+                ESP_LOGW(TAG, "s:%s d:%s !! unknown %li", source.c_str(), dest.c_str(), message.value);
             }
 
             if ((uint16_t)message.messageNumber == 0x4237)


### PR DESCRIPTION
(Re)Add missing default case to switch.

Without it it won't compile with ESP-IDF framework.

```
src/esphome/components/samsung_ac/protocol_nasa.cpp: In function 'void esphome::samsung_ac::process_messageset(std::__cxx11::string, std::__cxx11::string, esphome::samsung_ac::MessageSet&, esphome::samsung_ac::MessageTarget*)':
src/esphome/components/samsung_ac/protocol_nasa.cpp:463:20: error: enumeration value 'Undefiend' not handled in switch [-Werror=switch]
             switch (message.messageNumber)
                    ^
src/esphome/components/samsung_ac/protocol_nasa.cpp:463:20: error: enumeration value 'ENUM_in_fan_mode' not handled in switch [-Werror=switch]
Compiling .pioenvs/hvac-test/src/esphome/components/select/select_call.o
cc1plus: some warnings being treated as errors
*** [.pioenvs/hvac-test/src/esphome/components/samsung_ac/protocol_nasa.o] Error 1
========================= [FAILED] Took 10.60 seconds =========================
```