### PR TITLE
Send data after command f8 instead command c6

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -339,6 +339,7 @@ namespace esphome
                     {
                         auto data = nonnasa_requests.front().encode();
                         target->publish_data(data);
+                        ESP_LOGW(TAG, "NonNASA: Data send: %s", crc_actual, crc_expected, bytes_to_hex(data).c_str());
                         nonnasa_requests.pop();
                     }
                 }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -339,7 +339,7 @@ namespace esphome
                     {
                         auto data = nonnasa_requests.front().encode();
                         target->publish_data(data);
-                        auto data = nonnasa_requests.front().encode();
+                        data = nonnasa_requests.front().encode();
                         target->publish_data(data);
                         ESP_LOGW(TAG, "NonNASA: Data send: %s", bytes_to_hex(data).c_str());
                         nonnasa_requests.pop();

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -338,7 +338,7 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
-                        delay_ms(20);
+                        os_delay_us(20000);
                         target->publish_data(data);
                         //target->publish_data(data);
                         ESP_LOGW(TAG, "NonNASA: Data send: %s", bytes_to_hex(data).c_str());

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -329,7 +329,7 @@ namespace esphome
                 target->set_mode(nonpacket_.src, nonnasa_mode_to_mode(nonpacket_.command20.mode));
                 target->set_fanmode(nonpacket_.src, nonnasa_fanspeed_to_fanmode(nonpacket_.command20.fanspeed));
             }
-            else if (nonpacket_.cmd == 0xf8)
+            else if (nonpacket_.cmd == 0xf8) //After cmd F8 (srcc8 dstf0) is a lage gap in communication, time to send data
             {
                 if (nonpacket_.src == "c8" && nonpacket_.dst == "f0")
                 {
@@ -338,10 +338,8 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
-                        os_delay_us(20000);
                         target->publish_data(data);
-                        //target->publish_data(data);
-                        ESP_LOGW(TAG, "NonNASA: Data send: %s", bytes_to_hex(data).c_str());
+                        target->publish_data(data);  // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
                         nonnasa_requests.pop();
                     }
                 }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -339,6 +339,8 @@ namespace esphome
                     {
                         auto data = nonnasa_requests.front().encode();
                         target->publish_data(data);
+                        auto data = nonnasa_requests.front().encode();
+                        target->publish_data(data);
                         ESP_LOGW(TAG, "NonNASA: Data send: %s", bytes_to_hex(data).c_str());
                         nonnasa_requests.pop();
                     }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -339,7 +339,7 @@ namespace esphome
                     {
                         auto data = nonnasa_requests.front().encode();
                         target->publish_data(data);
-                        ESP_LOGW(TAG, "NonNASA: Data send: %s", crc_actual, crc_expected, bytes_to_hex(data).c_str());
+                        ESP_LOGW(TAG, "NonNASA: Data send: %s", bytes_to_hex(data).c_str());
                         nonnasa_requests.pop();
                     }
                 }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -98,6 +98,12 @@ namespace esphome
                 commandC6.control_status = data[4];
                 return DecodeResult::Ok;
             }
+            case 0xf8:
+            {
+                // only an free time-slot after src == "c8" && dst == "f0"
+                commandF8.control_status = data[4]; //?
+                return DecodeResult::Ok;
+            }
             default:
                 return DecodeResult::Ok;
             }
@@ -323,11 +329,11 @@ namespace esphome
                 target->set_mode(nonpacket_.src, nonnasa_mode_to_mode(nonpacket_.command20.mode));
                 target->set_fanmode(nonpacket_.src, nonnasa_fanspeed_to_fanmode(nonpacket_.command20.fanspeed));
             }
-            else if (nonpacket_.cmd == 0xc6)
+            else if (nonpacket_.cmd == 0xf8)
             {
-                if (nonpacket_.src == "c8" && nonpacket_.dst == "d0")
+                if (nonpacket_.src == "c8" && nonpacket_.dst == "f0")
                 {
-                    ESP_LOGW(TAG, "control_status=%d", nonpacket_.commandC6.control_status);
+                    ESP_LOGW(TAG, "control_status=%d", nonpacket_.commandF8.control_status);
 
                     while (nonnasa_requests.size() > 0)
                     {

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -338,9 +338,9 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
+                        delay_ms(20);
                         target->publish_data(data);
-                        data = nonnasa_requests.front().encode();
-                        target->publish_data(data);
+                        //target->publish_data(data);
                         ESP_LOGW(TAG, "NonNASA: Data send: %s", bytes_to_hex(data).c_str());
                         nonnasa_requests.pop();
                     }

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -61,6 +61,15 @@ namespace esphome
             };
         };
 
+        struct NonNasaCommandF8
+        {
+            bool control_status = false;
+            std::string to_string()
+            {
+                return "control_status:" + control_status;
+            };
+        };
+
         struct NonNasaDataPacket
         {
             std::string src;
@@ -76,6 +85,7 @@ namespace esphome
             {
                 NonNasaCommand20 command20;
                 NonNasaCommandC6 commandC6;
+                NonNasaCommandF8 commandF8;
             };
 
             DecodeResult decode(std::vector<uint8_t> &data);


### PR DESCRIPTION
Data in non-nasa-protocoll is send after command f8. Testet on my non-nasa-system with 2 indoor-units.
A little quick and dirty workaround is inside, i send the message twice get it to work. I think its a little timing problem. A small delay should work also, I think the message is send to fast after the last command. There are always ~50ms between the messages.