### PR TITLE
Non-Nasa send only one command when changing modes

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -236,6 +236,7 @@ namespace esphome
         void NonNasaProtocol::publish_mode_message(MessageTarget *target, const std::string &address, Mode value)
         {
             auto request = NonNasaRequest::create(address);
+            request.power = true;
             request.mode = mode_to_nonnasa_mode(value);
             nonnasa_requests.push(request);
         }

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -98,7 +98,6 @@ namespace esphome
         }
         else
         {
-          device->write_power(true);
           device->write_mode(climatemode_to_mode(modeOpt.value()));
         }
       }


### PR DESCRIPTION
Hello @lanwin 

Although I am using the F3 F4 serial bus I found I was having the same problem with changing modes that was reported in the issues section. This problem is that the change mode command appears to be processed but nothing happens and the current mode remains set on the unit.

After some digging I found that the change modes code was sending two commands to the unit in quick succession.

The first command would turn the unit on and use the current mode value as the nominated mode.

The second command would specify the new mode value to change to,

I am making an assumption now but I don't think that the unit likes having multiple commands sent to it so quickly. With only the first command being processed and any subsequent commands ignored.

To test this, I have changed the publish_mode_message function to always turn the unit on and remove the need for the two separate commands.

In my testing (again on F3 F4) this has resolved the issue and I can now reliably change the mode. I suspect it is likely this will also resolve the issue for the F1 F2 serial bus.