### PR TITLE
tested delay in non-nasa-communication

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -360,7 +360,7 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
-                        delay(10);
+                        delay(7);
                         target->publish_data(data);
                         //target->publish_data(data); // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
                         nonnasa_requests.pop();

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -361,7 +361,8 @@ namespace esphome
                     {
                         auto data = nonnasa_requests.front().encode();
                         target->publish_data(data);
-                        target->publish_data(data); // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
+                        //target->publish_data(data); // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
+                        delay(1);
                         nonnasa_requests.pop();
                     }
                 }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -360,7 +360,7 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
-                        delay(1);
+                        delay(10);
                         target->publish_data(data);
                         //target->publish_data(data); // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
                         nonnasa_requests.pop();

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -360,9 +360,10 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
-                        delay(7);
+                        //the communication needs a delay from cmdf8 to send the data.
+                        //series of test-delay-times: 1ms: no reaction, 7ms reactions half the time, 10ms very often a reaction (95%) -> delay on 20ms should be safe
+                        delay(20);
                         target->publish_data(data);
-                        //target->publish_data(data); // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
                         nonnasa_requests.pop();
                     }
                 }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -360,9 +360,9 @@ namespace esphome
                     while (nonnasa_requests.size() > 0)
                     {
                         auto data = nonnasa_requests.front().encode();
+                        delay(1);
                         target->publish_data(data);
                         //target->publish_data(data); // WORKAROUND: Send data twice. I think its a timing problem, sending data to fast after cmd f8. A delay should work also
-                        delay(1);
                         nonnasa_requests.pop();
                     }
                 }

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <optional>
 #include "protocol.h"
+#include "util.h"
 
 namespace esphome
 {

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -70,7 +70,7 @@ namespace esphome
             {
                 std::vector<uint8_t> vec(std::begin(data), std::begin(data) + length);
                 return bytes_to_hex(vec);
-            }
+            };
         };
 
         enum class NonNasaCommand : uint8_t


### PR DESCRIPTION
-had to fix a missing ";" and a missing include to get the code to compile

-removed sending command twice
-inserted the delay and tested for a optimal duration

1ms -> no execution of all commands
5ms -> 50% execution of the commands
10ms -> 95% execution of the commands

20ms delay worked all the time and should be safe (gap in communication after cmdf8 is around 300ms so there is enough time for this small delay)

testet ~100 times for indoor-unit 00 and 01 with no problems