### PR TITLE
Inverter power and thermal power requirement decoded

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -46,6 +46,7 @@ namespace esphome
             str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement) + ";";
             str += "inverter_current[ADC]:" + std::to_string(inverter_current) + ";";
             str += "inverter_voltage[VDC]:" + std::to_string(inverter_voltage) + ";";
+            str += "inverter_voltage[W]:" + std::to_string(inverter_power) + ";";
             return str;
         }
 

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -138,11 +138,11 @@ namespace esphome
             }
             case NonNasaCommand::CmdF3: // power consumption
             {
-                commandF3.inverter_max_frequency = data[4];
-                commandF3.inverter_total_capacity_requirement = (float)data[5] / 10;
-                commandF3.inverter_current = (float)data[8] / 10;
-                commandF3.inverter_voltage = (float)data[9] * 2;
-                commandF3.inverter_power = commandF3.inverter_current * commandF3.inverter_voltage;
+                commandF3.inverter_max_frequency = data[4]; // Maximum frequency for Inverter (compressor-motor of outdoor-unit) in Hz
+                commandF3.inverter_total_capacity_requirement = (float)data[5] / 10; // Sum of required heating/cooling capacity ordered by the indoor-units in W
+                commandF3.inverter_current = (float)data[8] / 10; // DC-current to the inverter of outdoor-unit in A
+                commandF3.inverter_voltage = (float)data[9] * 2; // voltage of the DC-link to inverter in V
+                commandF3.inverter_power = commandF3.inverter_current * commandF3.inverter_voltage; //Power consumption of the outdoo unit inverter in W
                 return DecodeResult::Ok;
             }
             default:

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -130,6 +130,15 @@ namespace esphome
                 commandC6.control_status = data[4];
                 return DecodeResult::Ok;
             }
+            case NonNasaCommand::CmdF3: // power consumption
+            {
+                commandF3.inverter_max_frequency = data[4];
+                commandF3.inverter_total_capacity_requirement = (float)data[5] / 10;
+                commandF3.inverter_current = (float)data[8] / 10;
+                commandF3.inverter_voltage = (float)data[9] * 2;
+                commandF3.inverter_power = inverter_current * inverter_voltage;
+                return DecodeResult::Ok;
+            }
             default:
             {
                 commandRaw.length = data.size() - 4 - 1;

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -141,7 +141,7 @@ namespace esphome
                 // Maximum frequency for Inverter (compressor-motor of outdoor-unit) in Hz
                 commandF3.inverter_max_frequency_hz = data[4]; 
                 // Sum of required heating/cooling capacity ordered by the indoor-units in kW
-                commandF3.inverter_total_capacity_requirement_w = (float)data[5] / 10; 
+                commandF3.inverter_total_capacity_requirement_kw = (float)data[5] / 10; 
                 // DC-current to the inverter of outdoor-unit in A
                 commandF3.inverter_current_a = (float)data[8] / 10; 
                 // voltage of the DC-link to inverter in V

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -39,6 +39,16 @@ namespace esphome
             return str;
         }
 
+        std::string NonNasaCommandF3::to_string()
+        {
+            std::string str;
+            str += "inverter_max_frequency[Hz]:" + std::to_string(inverter_max_frequency) + ";";
+            str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement) + ";";
+            str += "inverter_current[ADC]:" + std::to_string(inverter_current) + ";";
+            str += "inverter_voltage[VDC]:" + std::to_string(inverter_voltage) + ";";
+            return str;
+        }
+
         std::string NonNasaDataPacket::to_string()
         {
             std::string str;

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -42,11 +42,11 @@ namespace esphome
         std::string NonNasaCommandF3::to_string()
         {
             std::string str;
-            str += "inverter_max_frequency[Hz]:" + std::to_string(inverter_max_frequency) + ";";
-            str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement) + ";";
-            str += "inverter_current[ADC]:" + std::to_string(inverter_current) + ";";
-            str += "inverter_voltage[VDC]:" + std::to_string(inverter_voltage) + ";";
-            str += "inverter_power[W]:" + std::to_string(inverter_power) + ";";
+            str += "inverter_max_frequency[Hz]:" + std::to_string(inverter_max_frequency_hz) + ";";
+            str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement_w) + ";";
+            str += "inverter_current[ADC]:" + std::to_string(inverter_current_a) + ";";
+            str += "inverter_voltage[VDC]:" + std::to_string(inverter_voltage_v) + ";";
+            str += "inverter_power[W]:" + std::to_string(inverter_power_w) + ";";
             return str;
         }
 
@@ -138,11 +138,16 @@ namespace esphome
             }
             case NonNasaCommand::CmdF3: // power consumption
             {
-                commandF3.inverter_max_frequency = data[4]; // Maximum frequency for Inverter (compressor-motor of outdoor-unit) in Hz
-                commandF3.inverter_total_capacity_requirement = (float)data[5] / 10; // Sum of required heating/cooling capacity ordered by the indoor-units in W
-                commandF3.inverter_current = (float)data[8] / 10; // DC-current to the inverter of outdoor-unit in A
-                commandF3.inverter_voltage = (float)data[9] * 2; // voltage of the DC-link to inverter in V
-                commandF3.inverter_power = commandF3.inverter_current * commandF3.inverter_voltage; //Power consumption of the outdoo unit inverter in W
+                // Maximum frequency for Inverter (compressor-motor of outdoor-unit) in Hz
+                commandF3.inverter_max_frequency_hz = data[4]; 
+                // Sum of required heating/cooling capacity ordered by the indoor-units in W
+                commandF3.inverter_total_capacity_requirement_w = (float)data[5] / 10; 
+                // DC-current to the inverter of outdoor-unit in A
+                commandF3.inverter_current_a = (float)data[8] / 10; 
+                // voltage of the DC-link to inverter in V
+                commandF3.inverter_voltage_v = (float)data[9] * 2; 
+                //Power consumption of the outdoo unit inverter in W
+                commandF3.inverter_power_w = commandF3.inverter_current_a * commandF3.inverter_voltage_v; 
                 return DecodeResult::Ok;
             }
             default:

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -46,7 +46,7 @@ namespace esphome
             str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement) + ";";
             str += "inverter_current[ADC]:" + std::to_string(inverter_current) + ";";
             str += "inverter_voltage[VDC]:" + std::to_string(inverter_voltage) + ";";
-            str += "inverter_voltage[W]:" + std::to_string(inverter_power) + ";";
+            str += "inverter_power[W]:" + std::to_string(inverter_power) + ";";
             return str;
         }
 

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -43,7 +43,7 @@ namespace esphome
         {
             std::string str;
             str += "inverter_max_frequency[Hz]:" + std::to_string(inverter_max_frequency_hz) + ";";
-            str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement_w) + ";";
+            str += "inverter_total_capacity_requirement[kW]:" + std::to_string(inverter_total_capacity_requirement_kw) + ";";
             str += "inverter_current[ADC]:" + std::to_string(inverter_current_a) + ";";
             str += "inverter_voltage[VDC]:" + std::to_string(inverter_voltage_v) + ";";
             str += "inverter_power[W]:" + std::to_string(inverter_power_w) + ";";
@@ -140,7 +140,7 @@ namespace esphome
             {
                 // Maximum frequency for Inverter (compressor-motor of outdoor-unit) in Hz
                 commandF3.inverter_max_frequency_hz = data[4]; 
-                // Sum of required heating/cooling capacity ordered by the indoor-units in W
+                // Sum of required heating/cooling capacity ordered by the indoor-units in kW
                 commandF3.inverter_total_capacity_requirement_w = (float)data[5] / 10; 
                 // DC-current to the inverter of outdoor-unit in A
                 commandF3.inverter_current_a = (float)data[8] / 10; 

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -142,7 +142,7 @@ namespace esphome
                 commandF3.inverter_total_capacity_requirement = (float)data[5] / 10;
                 commandF3.inverter_current = (float)data[8] / 10;
                 commandF3.inverter_voltage = (float)data[9] * 2;
-                commandF3.inverter_power = inverter_current * inverter_voltage;
+                commandF3.inverter_power = commandF3.inverter_current * commandF3.inverter_voltage;
                 return DecodeResult::Ok;
             }
             default:

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -69,6 +69,11 @@ namespace esphome
                 str += "commandC6:{" + commandC6.to_string() + "}";
                 break;
             }
+            case NonNasaCommand::CmdF3:
+            {
+                str += "commandF3:{" + commandF3.to_string() + "}";
+                break;
+            }
             case NonNasaCommand::CmdF8:
             {
                 str += "commandF8:{" + commandF8.to_string() + "}";

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -68,6 +68,7 @@ namespace esphome
             float inverter_total_capacity_requirement = 0;
             float inverter_current = 0;
             float inverter_voltage = 0;
+            float inverter_power = 0;
 
             std::string to_string();
         };

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -64,11 +64,11 @@ namespace esphome
 
         struct NonNasaCommandF3
         {
-            uint8_t inverter_max_frequency = 0;
-            float inverter_total_capacity_requirement = 0;
-            float inverter_current = 0;
-            float inverter_voltage = 0;
-            float inverter_power = 0;
+            uint8_t inverter_max_frequency_hz = 0;
+            float inverter_total_capacity_requirement_kw = 0;
+            float inverter_current_a = 0;
+            float inverter_voltage_v = 0;
+            float inverter_power_w = 0;
 
             std::string to_string();
         };

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -62,6 +62,17 @@ namespace esphome
             };
         };
 
+        struct NonNasaCommandF3
+        {
+            uint8_t inverter_max_frequency = 0;
+            uint8_t inverter_total_capacity_requirement = 0;
+            uint8_t inverter_current = 0;
+            uint16_t inverter_voltage = 0;
+
+            std::string to_string();
+        };
+
+
         struct NonNasaCommandRaw
         {
             uint8_t length;
@@ -78,6 +89,7 @@ namespace esphome
         {
             Cmd20 = 0x20,
             CmdC6 = 0xc6,
+            CmdF3 = 0xf3,
             CmdF8 = 0xF8,
         };
 
@@ -96,6 +108,7 @@ namespace esphome
             {
                 NonNasaCommand20 command20;
                 NonNasaCommandC6 commandC6;
+                NonNasaCommandF3 commandF3;
                 NonNasaCommandRaw commandF8; // Unknown structure for now
                 NonNasaCommandRaw commandRaw;
             };

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -65,9 +65,9 @@ namespace esphome
         struct NonNasaCommandF3
         {
             uint8_t inverter_max_frequency = 0;
-            uint8_t inverter_total_capacity_requirement = 0;
-            uint8_t inverter_current = 0;
-            uint16_t inverter_voltage = 0;
+            float inverter_total_capacity_requirement = 0;
+            float inverter_current = 0;
+            float inverter_voltage = 0;
 
             std::string to_string();
         };


### PR DESCRIPTION
I had a few minutes ans so I extended the non-nasa-code to decode the F3-command

there we have now:
- the inverter max frequency
- the total power requirement for the outdoor unit
- the DC-current for the inverter of the OU
- the DC-voltage for the inverter of the OU
- the power-consupmtion for the inverter of the OU

with "debug_log_messages: true" enabled the values are shown correctly, no idea how to modify the code to get them to esphome. Thats your turn steve ;)