### PR TITLE
WindFree and other presets

### DIFF
--- a/components/samsung_ac/converions.cpp
+++ b/components/samsung_ac/converions.cpp
@@ -107,6 +107,60 @@ namespace esphome
         return FanMode::Auto;
       }
     }
+    
+    AltMode preset_to_altmode(climate::ClimatePreset preset)
+    {
+      switch (preset)
+      {
+      case climate::ClimatePreset::CLIMATE_PRESET_SLEEP:
+        return AltMode::Sleep;
+      case climate::ClimatePreset::CLIMATE_PRESET_NONE:
+      default:
+        return AltMode::None;
+      }
+    }
 
+    AltMode custompreset_to_altmode(const std::string &value)
+    {
+      if (value == "Quiet")
+        return AltMode::Quiet;
+      if (value == "Fast")
+        return AltMode::Fast;
+      if (value == "Long Reach")
+        return AltMode::LongReach;
+      if (value == "WindFree")
+        return AltMode::Windfree;
+      return AltMode::Unknown;
+    }
+
+    optional<climate::ClimatePreset> altmode_to_preset(AltMode mode)
+    {
+      switch (mode)
+      {
+      case AltMode::None:
+        return climate::ClimatePreset::CLIMATE_PRESET_NONE;
+      case AltMode::Sleep:
+        return climate::ClimatePreset::CLIMATE_PRESET_SLEEP;
+      default:
+        return nullopt;
+      };
+    }
+
+    std::string altmode_to_custompreset(AltMode mode)
+    {
+      switch (mode)
+      {
+      case AltMode::Quiet:
+        return "Quiet";
+      case AltMode::Fast:
+        return "Fast";
+      case AltMode::LongReach:
+        return "Long Reach";
+      case AltMode::Windfree:
+        return "WindFree";
+      default:
+        return "";
+      };
+    }
   } // namespace samsung_ac
 } // namespace esphome

--- a/components/samsung_ac/converions.cpp
+++ b/components/samsung_ac/converions.cpp
@@ -1,0 +1,112 @@
+#include "conversions.h"
+
+namespace esphome
+{
+  namespace samsung_ac
+  {
+    Mode str_to_mode(const std::string &value)
+    {
+      if (value == "Auto")
+        return Mode::Auto;
+      if (value == "Cool")
+        return Mode::Cool;
+      if (value == "Dry")
+        return Mode::Dry;
+      if (value == "Fan")
+        return Mode::Fan;
+      if (value == "Heat")
+        return Mode::Heat;
+      return Mode::Unknown;
+    }
+
+    std::string mode_to_str(Mode mode)
+    {
+      switch (mode)
+      {
+      case Mode::Auto:
+        return "Auto";
+      case Mode::Cool:
+        return "Cool";
+      case Mode::Dry:
+        return "Dry";
+      case Mode::Fan:
+        return "Fan";
+      case Mode::Heat:
+        return "Heat";
+      default:
+        return "";
+      };
+    }
+
+    optional<climate::ClimateMode> mode_to_climatemode(Mode mode)
+    {
+      switch (mode)
+      {
+      case Mode::Auto:
+        return climate::ClimateMode::CLIMATE_MODE_AUTO;
+      case Mode::Cool:
+        return climate::ClimateMode::CLIMATE_MODE_COOL;
+      case Mode::Dry:
+        return climate::ClimateMode::CLIMATE_MODE_DRY;
+      case Mode::Fan:
+        return climate::ClimateMode::CLIMATE_MODE_FAN_ONLY;
+      case Mode::Heat:
+        return climate::ClimateMode::CLIMATE_MODE_HEAT;
+      default:
+        return nullopt;
+      }
+    }
+
+    Mode climatemode_to_mode(climate::ClimateMode mode)
+    {
+      switch (mode)
+      {
+      case climate::ClimateMode::CLIMATE_MODE_COOL:
+        return Mode::Cool;
+      case climate::ClimateMode::CLIMATE_MODE_HEAT:
+        return Mode::Heat;
+      case climate::ClimateMode::CLIMATE_MODE_FAN_ONLY:
+        return Mode::Fan;
+      case climate::ClimateMode::CLIMATE_MODE_DRY:
+        return Mode::Dry;
+      case climate::ClimateMode::CLIMATE_MODE_AUTO:
+        return Mode::Auto;
+      default:
+        return Mode::Unknown;
+      }
+    }
+
+    climate::ClimateFanMode fanmode_to_climatefanmode(FanMode fanmode)
+    {
+      switch (fanmode)
+      {
+      case FanMode::Low:
+        return climate::ClimateFanMode::CLIMATE_FAN_LOW;
+      case FanMode::Mid:
+        return climate::ClimateFanMode::CLIMATE_FAN_MIDDLE;
+      case FanMode::Hight:
+        return climate::ClimateFanMode::CLIMATE_FAN_HIGH;
+      default:
+      case FanMode::Auto:
+        return climate::ClimateFanMode::CLIMATE_FAN_AUTO;
+      }
+    }
+
+    FanMode climatefanmode_to_fanmode(climate::ClimateFanMode fanmode)
+    {
+      switch (fanmode)
+      {
+      case climate::ClimateFanMode::CLIMATE_FAN_LOW:
+        return FanMode::Low;
+      case climate::ClimateFanMode::CLIMATE_FAN_MIDDLE:
+        return FanMode::Mid;
+      case climate::ClimateFanMode::CLIMATE_FAN_HIGH:
+        return FanMode::Hight;
+      case climate::ClimateFanMode::CLIMATE_FAN_AUTO:
+      default:
+        return FanMode::Auto;
+      }
+    }
+
+  } // namespace samsung_ac
+} // namespace esphome

--- a/components/samsung_ac/conversions.h
+++ b/components/samsung_ac/conversions.h
@@ -17,5 +17,10 @@ namespace esphome
     climate::ClimateFanMode fanmode_to_climatefanmode(FanMode fanmode);
     FanMode climatefanmode_to_fanmode(climate::ClimateFanMode fanmode);
 
+    optional<climate::ClimatePreset> altmode_to_preset(AltMode mode);
+    std::string altmode_to_custompreset(AltMode mode);
+    AltMode preset_to_altmode(climate::ClimatePreset preset);
+    AltMode custompreset_to_altmode(const std::string &value);
+
   } // namespace samsung_ac
 } // namespace esphome

--- a/components/samsung_ac/conversions.h
+++ b/components/samsung_ac/conversions.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <optional>
+#include "esphome/components/climate/climate.h"
+#include "protocol.h"
+
+namespace esphome
+{
+  namespace samsung_ac{
+
+    Mode str_to_mode(const std::string &value);
+    std::string mode_to_str(Mode mode);
+
+    optional<climate::ClimateMode> mode_to_climatemode(Mode mode);
+    Mode climatemode_to_mode(climate::ClimateMode mode);
+
+    climate::ClimateFanMode fanmode_to_climatefanmode(FanMode fanmode);
+    FanMode climatefanmode_to_fanmode(climate::ClimateFanMode fanmode);
+
+  } // namespace samsung_ac
+} // namespace esphome

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -41,6 +41,18 @@ namespace esphome
             Off = 5
         };
 
+
+        enum class AltMode
+        {
+            Unknown = -1,
+            None = 0,
+            Sleep = 1,
+            Quiet = 2,
+            Fast = 3,
+            LongReach = 4,
+            Windfree = 5
+        };
+
         class MessageTarget
         {
         public:
@@ -53,6 +65,7 @@ namespace esphome
             virtual void set_target_temperature(const std::string address, float value) = 0;
             virtual void set_mode(const std::string address, Mode mode) = 0;
             virtual void set_fanmode(const std::string address, FanMode fanmode) = 0;
+            virtual void set_altmode(const std::string address, AltMode fanmode) = 0;
         };
 
         class Protocol
@@ -62,6 +75,7 @@ namespace esphome
             virtual void publish_target_temp_message(MessageTarget *target, const std::string &address, float value) = 0;
             virtual void publish_mode_message(MessageTarget *target, const std::string &address, Mode value) = 0;
             virtual void publish_fanmode_message(MessageTarget *target, const std::string &address, FanMode value) = 0;
+            virtual void publish_altmode_message(MessageTarget *target, const std::string &address, AltMode value) = 0;
         };
 
         enum class DataResult

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -74,6 +74,7 @@ namespace esphome
             ENUM_in_operation_mode = 0x4001,
             ENUM_in_fan_mode = 0x4006, // Did not exists in xml...only in Remocon.dll code
             ENUM_in_fan_mode_real = 0x4007,
+            ENUM_in_alt_mode = 0x4060,
             ENUM_in_state_humidity_percent = 0x4038,
             VAR_in_temp_room_f = 0x4203,
             VAR_in_temp_target_f = 0x4201,
@@ -168,6 +169,7 @@ namespace esphome
             void publish_target_temp_message(MessageTarget *target, const std::string &address, float value) override;
             void publish_mode_message(MessageTarget *target, const std::string &address, Mode value) override;
             void publish_fanmode_message(MessageTarget *target, const std::string &address, FanMode value) override;
+            void publish_altmode_message(MessageTarget *target, const std::string &address, AltMode value) override;
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -321,6 +321,11 @@ namespace esphome
             nonnasa_requests.push(request);
         }
 
+        void NonNasaProtocol::publish_altmode_message(MessageTarget *target, const std::string &address, AltMode value)
+        {
+            // TODO
+        }
+
         Mode nonnasa_mode_to_mode(NonNasaMode value)
         {
             switch (value)
@@ -380,6 +385,8 @@ namespace esphome
                 target->set_power(nonpacket_.src, nonpacket_.command20.power);
                 target->set_mode(nonpacket_.src, nonnasa_mode_to_mode(nonpacket_.command20.mode));
                 target->set_fanmode(nonpacket_.src, nonnasa_fanspeed_to_fanmode(nonpacket_.command20.fanspeed));
+                // TODO
+                target->set_altmode(nonpacket_.src, AltMode::None);
             }
             else if (nonpacket_.cmd == NonNasaCommand::CmdF8)
             {

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -146,6 +146,7 @@ namespace esphome
             void publish_target_temp_message(MessageTarget *target, const std::string &address, float value) override;
             void publish_mode_message(MessageTarget *target, const std::string &address, Mode value) override;
             void publish_fanmode_message(MessageTarget *target, const std::string &address, FanMode value) override;
+            void publish_altmode_message(MessageTarget *target, const std::string &address, AltMode value) override;
         };
     } // namespace samsung_ac
 } // namespace esphome

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -103,6 +103,13 @@ namespace esphome
           dev->publish_fanmode(fanmode);
       }
 
+      void /*MessageTarget::*/ set_altmode(const std::string address, AltMode altmode) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->publish_altmode(altmode);
+      }
+
     protected:
       Samsung_AC_Device *find_device(const std::string address)
       {

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -46,41 +46,6 @@ namespace esphome
       return traits;
     }
 
-    Mode climatemode_to_mode(climate::ClimateMode mode)
-    {
-      switch (mode)
-      {
-      case climate::ClimateMode::CLIMATE_MODE_COOL:
-        return Mode::Cool;
-      case climate::ClimateMode::CLIMATE_MODE_HEAT:
-        return Mode::Heat;
-      case climate::ClimateMode::CLIMATE_MODE_FAN_ONLY:
-        return Mode::Fan;
-      case climate::ClimateMode::CLIMATE_MODE_DRY:
-        return Mode::Dry;
-      case climate::ClimateMode::CLIMATE_MODE_AUTO:
-        return Mode::Auto;
-      default:
-        return Mode::Unknown;
-      }
-    }
-
-    FanMode climatefanmode_to_fanmode(climate::ClimateFanMode fanmode)
-    {
-      switch (fanmode)
-      {
-      case climate::ClimateFanMode::CLIMATE_FAN_LOW:
-        return FanMode::Low;
-      case climate::ClimateFanMode::CLIMATE_FAN_MIDDLE:
-        return FanMode::Mid;
-      case climate::ClimateFanMode::CLIMATE_FAN_HIGH:
-        return FanMode::Hight;
-      case climate::ClimateFanMode::CLIMATE_FAN_AUTO:
-      default:
-        return FanMode::Auto;
-      }
-    }
-
     void Samsung_AC_Climate::control(const climate::ClimateCall &call)
     {
       traits();

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -1,6 +1,7 @@
 #include "esphome/core/log.h"
 #include "samsung_ac.h"
 #include "util.h"
+#include "conversions.h"
 #include <vector>
 
 namespace esphome
@@ -43,6 +44,18 @@ namespace esphome
 
       traits.set_supported_fan_modes(fan);
 
+      std::set<climate::ClimatePreset> preset;
+      preset.insert(climate::ClimatePreset::CLIMATE_PRESET_NONE);
+      preset.insert(climate::ClimatePreset::CLIMATE_PRESET_SLEEP);
+      traits.set_supported_presets(preset);
+
+      std::set<std::string> customPreset;
+      customPreset.insert("Quiet");
+      customPreset.insert("Fast");
+      customPreset.insert("Long Reach");
+      customPreset.insert("WindFree");
+      traits.set_supported_custom_presets(customPreset);
+
       return traits;
     }
 
@@ -72,6 +85,18 @@ namespace esphome
       {
         device->write_fanmode(climatefanmode_to_fanmode(fanmodeOpt.value()));
       }
+
+      auto presetOpt = call.get_preset();
+      if (presetOpt.has_value())
+      {
+        device->write_altmode(preset_to_altmode(presetOpt.value()));
+      }
+
+      auto customPresetOpt = call.get_custom_preset();
+      if (customPresetOpt.has_value())
+      {
+        device->write_altmode(custompreset_to_altmode(customPresetOpt.value()));
+      }
     }
 
     void Samsung_AC_Device::write_target_temperature(float value)
@@ -87,6 +112,11 @@ namespace esphome
     void Samsung_AC_Device::write_fanmode(FanMode value)
     {
       protocol->publish_fanmode_message(samsung_ac, address, value);
+    }
+
+    void Samsung_AC_Device::write_altmode(AltMode value)
+    {
+      protocol->publish_altmode_message(samsung_ac, address, value);
     }
 
     void Samsung_AC_Device::write_power(bool value)

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -9,6 +9,7 @@
 #include "esphome/components/climate/climate.h"
 #include "protocol.h"
 #include "samsung_ac.h"
+#include "conversions.h"
 
 namespace esphome
 {
@@ -166,6 +167,22 @@ namespace esphome
         }
       }
 
+      void publish_altmode(AltMode value)
+      {
+        if (climate != nullptr)
+        {
+          auto preset = altmode_to_preset(value);
+          if (preset.has_value()) {
+            climate->preset = preset;
+            climate->custom_preset.reset();
+          } else {
+            climate->preset.reset();
+            climate->custom_preset = altmode_to_custompreset(value);
+          }
+          climate->publish_state();
+        }
+      }
+
       void publish_room_temperature(float value)
       {
         if (room_temperature != nullptr)
@@ -186,6 +203,7 @@ namespace esphome
       void write_target_temperature(float value);
       void write_mode(Mode value);
       void write_fanmode(FanMode value);
+      void write_altmode(AltMode value);
       void write_power(bool value);
 
     protected:

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -38,40 +38,6 @@ namespace esphome
     class Samsung_AC_Mode_Select : public select::Select
     {
     public:
-      Mode str_to_mode(const std::string &value)
-      {
-        if (value == "Auto")
-          return Mode::Auto;
-        if (value == "Cool")
-          return Mode::Cool;
-        if (value == "Dry")
-          return Mode::Dry;
-        if (value == "Fan")
-          return Mode::Fan;
-        if (value == "Heat")
-          return Mode::Heat;
-        return Mode::Unknown;
-      }
-
-      std::string mode_to_str(Mode mode)
-      {
-        switch (mode)
-        {
-        case Mode::Auto:
-          return "Auto";
-        case Mode::Cool:
-          return "Cool";
-        case Mode::Dry:
-          return "Dry";
-        case Mode::Fan:
-          return "Fan";
-        case Mode::Heat:
-          return "Heat";
-        default:
-          return "";
-        };
-      }
-
       void publish_state_(Mode mode)
       {
         this->publish_state(mode_to_str(mode));
@@ -225,41 +191,6 @@ namespace esphome
     protected:
       Protocol *protocol{nullptr};
       Samsung_AC *samsung_ac{nullptr};
-
-      optional<climate::ClimateMode> mode_to_climatemode(Mode mode)
-      {
-        switch (mode)
-        {
-        case Mode::Auto:
-          return climate::ClimateMode::CLIMATE_MODE_AUTO;
-        case Mode::Cool:
-          return climate::ClimateMode::CLIMATE_MODE_COOL;
-        case Mode::Dry:
-          return climate::ClimateMode::CLIMATE_MODE_DRY;
-        case Mode::Fan:
-          return climate::ClimateMode::CLIMATE_MODE_FAN_ONLY;
-        case Mode::Heat:
-          return climate::ClimateMode::CLIMATE_MODE_HEAT;
-        default:
-          return nullopt;
-        }
-      }
-
-      climate::ClimateFanMode fanmode_to_climatefanmode(FanMode fanmode)
-      {
-        switch (fanmode)
-        {
-        case FanMode::Low:
-          return climate::ClimateFanMode::CLIMATE_FAN_LOW;
-        case FanMode::Mid:
-          return climate::ClimateFanMode::CLIMATE_FAN_MIDDLE;
-        case FanMode::Hight:
-          return climate::ClimateFanMode::CLIMATE_FAN_HIGH;
-        default:
-        case FanMode::Auto:
-          return climate::ClimateFanMode::CLIMATE_FAN_AUTO;
-        }
-      }
 
       void calc_and_publish_mode()
       {


### PR DESCRIPTION
Added support for setting different presets via `NASA_ALTERNATIVE_MODE`.

On my AR09TXFCAWKNEU (3 indoor units), I have three, Quiet (2), Fast (3) and WindFree (9). In #3 another one, Long Reach (6) was mentioned, so there could be more in the wild.
Additional config to enable/disable different modes might be required in the future.

I went with the presets/custom_presets approach, but on the other hand, all three that I tested with are mutually exclusive with fan modes, so they could also be considered as custom_fan_modes instead.

Fixes #3 
Fixes #41 