### PR TITLE
[NASA] Custom sensors

### DIFF
--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include "esphome/core/optional.h"
 #include "util.h"
 
@@ -77,6 +78,8 @@ namespace esphome
             virtual void set_altmode(const std::string address, AltMode fanmode) = 0;
             virtual void set_swing_vertical(const std::string address, bool vertical) = 0;
             virtual void set_swing_horizontal(const std::string address, bool horizontal) = 0;
+            virtual optional<std::set<uint16_t>> get_custom_sensors(const std::string address) = 0;
+            virtual void set_custom_sensor(const std::string address, uint16_t message_number, float value) = 0;
         };
 
         struct ProtocolRequest

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -138,6 +138,21 @@ namespace esphome
           dev->update_swing_horizontal(horizontal);
       }
 
+      optional<std::set<uint16_t>> /*MessageTarget::*/ get_custom_sensors(const std::string address) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          return optional<std::set<uint16_t>>(dev->get_custom_sensors());
+        return optional<std::set<uint16_t>>();
+      }
+      
+      void /*MessageTarget::*/ set_custom_sensor(const std::string address, uint16_t message_number, float value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_custom_sensor(message_number, value);
+      }
+
     protected:
       Samsung_AC_Device *find_device(const std::string address)
       {

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -3,6 +3,7 @@
 #include "util.h"
 #include "conversions.h"
 #include <vector>
+#include <set>
 
 namespace esphome
 {

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -65,6 +65,12 @@ namespace esphome
       }
     };
 
+    struct Samsung_AC_Sensor
+    {
+      uint16_t message_number;
+      sensor::Sensor *sensor;
+    };
+
     class Samsung_AC_Device
     {
     public:
@@ -84,6 +90,7 @@ namespace esphome
       Samsung_AC_Switch *power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Climate *climate{nullptr};
+      std::vector<Samsung_AC_Sensor> custom_sensors;
 
       void set_room_temperature_sensor(sensor::Sensor *sensor)
       {
@@ -103,6 +110,22 @@ namespace esphome
       void set_room_humidity_sensor(sensor::Sensor *sensor)
       {
         room_humidity = sensor;
+      }
+
+      void add_custom_sensor(int message_number, sensor::Sensor *sensor)
+      {
+        Samsung_AC_Sensor cust_sensor;
+        cust_sensor.message_number = (uint16_t) message_number;
+        cust_sensor.sensor = sensor;
+        custom_sensors.push_back(std::move(cust_sensor));
+      }
+
+      std::set<uint16_t> get_custom_sensors()
+      {
+        std::set<uint16_t> numbers;
+        for (auto &sensor: custom_sensors)
+          numbers.insert(sensor.message_number);
+        return numbers;
       }
 
       void set_power_switch(Samsung_AC_Switch *switch_)
@@ -261,6 +284,13 @@ namespace esphome
       {
         if (room_humidity != nullptr)
           room_humidity->publish_state(value);
+      }
+
+      void update_custom_sensor(uint16_t message_number, float value)
+      {
+        for (auto &sensor: custom_sensors)
+          if (sensor.message_number == message_number)
+            sensor.sensor->publish_state(value);
       }
 
       void publish_request(ProtocolRequest &request)


### PR DESCRIPTION
Allow specifying arbitrary message numbers with numeric values. and map them to sensors.

Example:
```
  devices:
    - address: "10.00.00"
      custom_sensor:
        - name: Voltage
          message: 0x24fc
          device_class: voltage
          state_class: measurement
          unit_of_measurement: V
        - name: Current
          message: 0x82db
          device_class: current
          state_class: measurement
          unit_of_measurement: A
        - name: Instant power
          message: 0x8411
          device_class: energy
          state_class: measurement
          unit_of_measurement: Wh
        - name: Total power
          message: 0x8414
          device_class: energy
          state_class: total_increasing
          unit_of_measurement: Wh
```