### PR TITLE
Allow configuring alt and swing modes

### DIFF
--- a/components/samsung_ac/conversions.cpp
+++ b/components/samsung_ac/conversions.cpp
@@ -128,59 +128,49 @@ namespace esphome
       return FanMode::Auto;
     }
 
-    AltMode preset_to_altmode(climate::ClimatePreset preset)
+    AltModeName preset_to_altmodename(climate::ClimatePreset preset)
     {
       switch (preset)
       {
+      case climate::ClimatePreset::CLIMATE_PRESET_ECO:
+        return "Eco";
+      case climate::ClimatePreset::CLIMATE_PRESET_AWAY:
+        return "Away";
+      case climate::ClimatePreset::CLIMATE_PRESET_BOOST:
+        return "Boost";
+      case climate::ClimatePreset::CLIMATE_PRESET_COMFORT:
+        return "Comfort";
+      case climate::ClimatePreset::CLIMATE_PRESET_HOME:
+        return "Home";
       case climate::ClimatePreset::CLIMATE_PRESET_SLEEP:
-        return AltMode::Sleep;
+        return "Sleep";
+      case climate::ClimatePreset::CLIMATE_PRESET_ACTIVITY:
+        return "Activity";
       case climate::ClimatePreset::CLIMATE_PRESET_NONE:
       default:
-        return AltMode::None;
+        return "None";
       }
     }
 
-    AltMode custompreset_to_altmode(const std::string &value)
+    optional<climate::ClimatePreset> altmodename_to_preset(const AltModeName& name)
     {
-      if (value == "Quiet")
-        return AltMode::Quiet;
-      if (value == "Fast")
-        return AltMode::Fast;
-      if (value == "Long Reach")
-        return AltMode::LongReach;
-      if (value == "WindFree")
-        return AltMode::Windfree;
-      return AltMode::Unknown;
-    }
-
-    optional<climate::ClimatePreset> altmode_to_preset(AltMode mode)
-    {
-      switch (mode)
-      {
-      case AltMode::None:
-        return climate::ClimatePreset::CLIMATE_PRESET_NONE;
-      case AltMode::Sleep:
-        return climate::ClimatePreset::CLIMATE_PRESET_SLEEP;
-      default:
-        return nullopt;
-      };
-    }
-
-    std::string altmode_to_custompreset(AltMode mode)
-    {
-      switch (mode)
-      {
-      case AltMode::Quiet:
-        return "Quiet";
-      case AltMode::Fast:
-        return "Fast";
-      case AltMode::LongReach:
-        return "Long Reach";
-      case AltMode::Windfree:
-        return "WindFree";
-      default:
-        return "";
-      };
+      if (str_equals_case_insensitive(name, "ECO"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_ECO);
+      if (str_equals_case_insensitive(name, "AWAY"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_AWAY);
+      if (str_equals_case_insensitive(name, "BOOST"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_BOOST);
+      if (str_equals_case_insensitive(name, "COMFORT"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_COMFORT);
+      if (str_equals_case_insensitive(name, "HOME"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_HOME);
+      if (str_equals_case_insensitive(name, "SLEEP"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_SLEEP);
+      if (str_equals_case_insensitive(name, "ACTIVITY"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_ACTIVITY);
+      if (str_equals_case_insensitive(name, "NONE"))
+        return optional<climate::ClimatePreset>(climate::CLIMATE_PRESET_NONE);
+      return nullopt;
     }
 
     climate::ClimateSwingMode swingmode_to_climateswingmode(SwingMode swingMode)

--- a/components/samsung_ac/conversions.h
+++ b/components/samsung_ac/conversions.h
@@ -19,10 +19,8 @@ namespace esphome
     FanMode climatefanmode_to_fanmode(climate::ClimateFanMode fanmode);
     FanMode customfanmode_to_fanmode(const std::string &value);
 
-    optional<climate::ClimatePreset> altmode_to_preset(AltMode mode);
-    std::string altmode_to_custompreset(AltMode mode);
-    AltMode preset_to_altmode(climate::ClimatePreset preset);
-    AltMode custompreset_to_altmode(const std::string &value);
+    AltModeName preset_to_altmodename(climate::ClimatePreset preset);
+    optional<climate::ClimatePreset> altmodename_to_preset(const AltModeName& name);
 
     climate::ClimateSwingMode swingmode_to_climateswingmode(SwingMode swingMode);
     SwingMode climateswingmode_to_swingmode(climate::ClimateSwingMode swingMode);

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -42,15 +42,13 @@ namespace esphome
             Off = 5
         };
 
-        enum class AltMode
+        typedef std::string AltModeName;
+        typedef uint8_t AltMode;
+
+        struct AltModeDesc
         {
-            Unknown = -1,
-            None = 0,
-            Sleep = 1,
-            Quiet = 2,
-            Fast = 3,
-            LongReach = 4,
-            Windfree = 5
+            AltModeName name;
+            AltMode value;
         };
 
         enum class SwingMode : uint8_t
@@ -73,7 +71,7 @@ namespace esphome
             virtual void set_outdoor_temperature(const std::string address, float value) = 0;
             virtual void set_mode(const std::string address, Mode mode) = 0;
             virtual void set_fanmode(const std::string address, FanMode fanmode) = 0;
-            virtual void set_altmode(const std::string address, AltMode fanmode) = 0;
+            virtual void set_altmode(const std::string address, AltMode altmode) = 0;
             virtual void set_swing_vertical(const std::string address, bool vertical) = 0;
             virtual void set_swing_horizontal(const std::string address, bool horizontal) = 0;
             virtual optional<std::set<uint16_t>> get_custom_sensors(const std::string address) = 0;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -367,26 +367,6 @@ namespace esphome
             }
         }
 
-        int altmode_to_nasa_altmode(AltMode mode)
-        {
-            switch (mode)
-            {
-            case AltMode::Sleep:
-                return 1;
-            case AltMode::Quiet:
-                return 2;
-            case AltMode::Fast:
-                return 3;
-            case AltMode::LongReach:
-                return 6;
-            case AltMode::Windfree:
-                return 9;
-            case AltMode::None:
-            default:
-                return 0;
-            }
-        }
-
         void NasaProtocol::publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request)
         {
             Packet packet = Packet::createa_partial(Address::parse(address), DataType::Request);
@@ -424,7 +404,7 @@ namespace esphome
             if (request.alt_mode)
             {
                 MessageSet altmode(MessageNumber::ENUM_in_alt_mode);
-                altmode.value = altmode_to_nasa_altmode(request.alt_mode.value());
+                altmode.value = request.alt_mode.value();
                 packet.messages.push_back(altmode);
             }
 
@@ -498,27 +478,6 @@ namespace esphome
             case 19: // NaturalHigh
             default:
                 return FanMode::Unknown;
-            }
-        }
-
-        AltMode altmode_to_nasa_altmode(int value)
-        {
-            switch (value)
-            {
-            case 0:
-                return AltMode::None;
-            case 1:
-                return AltMode::Sleep;
-            case 2:
-                return AltMode::Quiet;
-            case 3:
-                return AltMode::Fast;
-            case 6:
-                return AltMode::LongReach;
-            case 9:
-                return AltMode::Windfree;
-            default:
-                return AltMode::Unknown;
             }
         }
 
@@ -605,7 +564,7 @@ namespace esphome
             case MessageNumber::ENUM_in_alt_mode:
             {
                 ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c_str(), dest.c_str(), message.value);
-                target->set_altmode(source, altmode_to_nasa_altmode(message.value));
+                target->set_altmode(source, message.value);
                 return;
             }
             case MessageNumber::ENUM_in_louver_hl_swing:

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -497,7 +497,7 @@ namespace esphome
                 target->set_mode(nonpacket_.src, nonnasa_mode_to_mode(nonpacket_.command20.mode));
                 target->set_fanmode(nonpacket_.src, nonnasa_fanspeed_to_fanmode(nonpacket_.command20.fanspeed));
                 // TODO
-                target->set_altmode(nonpacket_.src, AltMode::None);
+                target->set_altmode(nonpacket_.src, 0);
                 // TODO
                 target->set_swing_horizontal(nonpacket_.src, false);
                 target->set_swing_vertical(nonpacket_.src, false);


### PR DESCRIPTION
Allows configuring capabilities for all devices at once or for specific ones.
Example:

```
samsung_ac:
  capabilities:
    supports_horizontal_swing: false
    alt_modes:
      - { name: "Quiet", value : 2 }
      - { name: "Fast", value : 3 }
      - { name: "WindFree", value : 9 }

  devices:
    - address: "20.00.01"
      # inherits global config
      climate:
        name: ...

    - address: "20.00.01"
      # doesn't support any swing modes, inherits alt modes
      capabilities:
        supports_vertical_swing: false
      climate:
        name: ...

    - address: "20.00.02"
      # supports both swing modes, but only one alt mode (with a custom name)
      capabilities:
        supports_horizontal_swing: true
        alt_modes:
          - { name: "My custom name for WindFree", value : 9 }
      ...
```