### PR TITLE
Controller Registration, Command Resending, and Keepalive Support for Non-NASA Devices

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -204,6 +204,8 @@ CONF_DEBUG_MQTT_PASSWORD = "debug_mqtt_password"
 CONF_DEBUG_LOG_MESSAGES = "debug_log_messages"
 CONF_DEBUG_LOG_MESSAGES_RAW = "debug_log_messages_raw"
 
+CONF_NON_NASA_KEEPALIVE = "non_nasa_keepalive"
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -215,6 +217,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_DEBUG_MQTT_PASSWORD, default=""): cv.string,
             cv.Optional(CONF_DEBUG_LOG_MESSAGES, default=False): cv.boolean,
             cv.Optional(CONF_DEBUG_LOG_MESSAGES_RAW, default=False): cv.boolean,
+            cv.Optional(CONF_NON_NASA_KEEPALIVE, default=False): cv.boolean,
             cv.Optional(CONF_CAPABILITIES): CAPABILITIES_SCHEMA,
             cv.Required(CONF_DEVICES): cv.ensure_list(DEVICE_SCHEMA),
         }
@@ -350,6 +353,9 @@ async def to_code(config):
     if (CONF_DEBUG_LOG_MESSAGES_RAW in config):
         cg.add(var.set_debug_log_messages_raw(
             config[CONF_DEBUG_LOG_MESSAGES_RAW]))
+            
+    if (CONF_NON_NASA_KEEPALIVE in config):
+        cg.add(var.set_non_nasa_keepalive(config[CONF_NON_NASA_KEEPALIVE]))
 
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/components/samsung_ac/protocol.cpp
+++ b/components/samsung_ac/protocol.cpp
@@ -10,6 +10,7 @@ namespace esphome
     {
         bool debug_log_packets = false;
         bool debug_log_raw_bytes = false;
+        bool non_nasa_keepalive = false;
 
         // This functions is designed to run after a new value was added
         // to the data vector. One by one.

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -93,6 +93,7 @@ namespace esphome
         {
         public:
             virtual void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) = 0;
+			virtual void protocol_update(MessageTarget *target) = 0;
         };
 
         enum class DataResult

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -97,6 +97,15 @@ namespace esphome
 			virtual void protocol_update(MessageTarget *target) = 0;
         };
 
+		enum class ProtocolProcessing
+		{
+			Auto = 0,
+			NASA = 1,
+			NonNASA = 2
+		};
+	
+		extern ProtocolProcessing protocol_processing;
+	
         enum class DataResult
         {
             Fill = 0,

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -10,6 +10,7 @@ namespace esphome
     {
         extern bool debug_log_packets;
         extern bool debug_log_raw_bytes;
+        extern bool non_nasa_keepalive;
 
         enum class DecodeResult
         {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1176,6 +1176,11 @@ namespace esphome
             }
             return;
         }
+	
+	void NasaProtocol::protocol_update(MessageTarget *target)
+	{
+		// Unused for NASA protocol
+	}
 
     } // namespace samsung_ac
 } // namespace esphome

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -170,6 +170,7 @@ namespace esphome
             NasaProtocol() = default;
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
+			void protocol_update(MessageTarget *target) override;
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -162,11 +162,11 @@ namespace esphome
             if (data[0] != 0x32)
                 return DecodeResult::InvalidStartByte;
 
+			if (data.size() != 14)
+				return DecodeResult::UnexpectedSize;
+			
             if (data[data.size() - 1] != 0x34)
                 return DecodeResult::InvalidEndByte;
-
-            if (data.size() != 7 && data.size() != 14)
-                return DecodeResult::UnexpectedSize;
 
             auto crc_expected = build_checksum(data);
             auto crc_actual = data[data.size() - 2];

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -563,6 +563,19 @@ namespace esphome
 					}
                 }
             }
+			else if (nonpacket_.src == "c8" && nonpacket_.dst == "ad" && (nonpacket_.commandRaw.data[0] & 1) == 1)
+			{
+				// We have received a broadcast registration request. It isn't necessary to register
+				// more than once, however we can use this as a keepalive method. A 30ms delay is added
+				// to allow other controllers to register. This mimics SNET Pro behaviour.
+				// It's unknown why the first data byte must be odd.
+				if (non_nasa_keepalive)
+				{
+					ESP_LOGD(TAG, "KEEPALIVE KEEPALIVE KEEPALIVE");
+					delay(30);
+					send_register_controller(target);
+				}
+			}
         }
 	
         void NonNasaProtocol::protocol_update(MessageTarget *target)

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -571,7 +571,6 @@ namespace esphome
 				// It's unknown why the first data byte must be odd.
 				if (non_nasa_keepalive)
 				{
-					ESP_LOGD(TAG, "KEEPALIVE KEEPALIVE KEEPALIVE");
 					delay(30);
 					send_register_controller(target);
 				}

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <queue>
 #include <vector>
 #include <iostream>
 #include <optional>
@@ -188,6 +189,17 @@ namespace esphome
             static NonNasaRequest create(std::string dst_address);
         };
 
+		struct NonNasaRequestQueueItem
+		{
+			NonNasaRequest request;
+			uint32_t time;
+			uint8_t retry_count;
+		};
+
+		extern std::queue<NonNasaRequestQueueItem> nonnasa_requests;
+		extern bool controller_registered;
+		extern bool indoor_unit_awake;
+	
         DecodeResult try_decode_non_nasa_packet(std::vector<uint8_t> data);
         void process_non_nasa_packet(MessageTarget *target);
 
@@ -197,6 +209,7 @@ namespace esphome
             NonNasaProtocol() = default;
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
+			void protocol_update(MessageTarget *target) override;
         };
     } // namespace samsung_ac
 } // namespace esphome

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <queue>
+#include <list>
 #include <vector>
 #include <iostream>
 #include <optional>
@@ -136,6 +136,7 @@ namespace esphome
         enum class NonNasaCommand : uint8_t
         {
             Cmd20 = 0x20,
+			Cmd54 = 0x54,
             CmdC0 = 0xc0,
             CmdC1 = 0xc1,
             CmdC6 = 0xc6,
@@ -159,6 +160,7 @@ namespace esphome
             union
             {
                 NonNasaCommand20 command20;
+				NonNasaCommandRaw command54; // Control message ack
                 NonNasaCommandC0 commandC0;
                 NonNasaCommandC1 commandC1;
                 NonNasaCommandC6 commandC6;
@@ -193,10 +195,12 @@ namespace esphome
 		{
 			NonNasaRequest request;
 			uint32_t time;
+			uint32_t time_sent;
 			uint8_t retry_count;
+			uint8_t resend_count;
 		};
 
-		extern std::queue<NonNasaRequestQueueItem> nonnasa_requests;
+		extern std::list<NonNasaRequestQueueItem> nonnasa_requests;
 		extern bool controller_registered;
 		extern bool indoor_unit_awake;
 	

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -46,6 +46,11 @@ namespace esphome
       {
         debug_log_raw_bytes = value;
       }
+		
+      void set_non_nasa_keepalive(bool value)
+      {
+        non_nasa_keepalive = value;
+      }
 
       void register_device(Samsung_AC_Device *device);
 

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -156,6 +156,7 @@ namespace esphome
       std::queue<std::vector<uint8_t>> send_queue_;
       std::vector<uint8_t> data_;
       uint32_t last_transmission_{0};
+      uint32_t last_protocol_update_{0};
 
       bool data_processing_init = true;
 

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -326,6 +326,14 @@ namespace esphome
       {
         room_temperature_offset = value;
       }
+		
+      void protocol_update(MessageTarget *target)
+      {
+        if (protocol != nullptr)
+        {
+			protocol->protocol_update(target);
+        }
+      }
 
     protected:
       bool supports_horizontal_swing_{true};

--- a/example.yaml
+++ b/example.yaml
@@ -114,3 +114,6 @@ samsung_ac:
       outdoor_temperature: # Should be used with outdoor device address
         name: "Outdoor temperature"
 
+  # For NonNASA devices the following option can be enabled to prevent the device from sleeping when idle. This allows
+  # values like internal and external temperature to continue to be tracked when the device isn't in use.
+  #non_nasa_keepalive: true


### PR DESCRIPTION
This PR addresses several issues when attempting to control Non-NASA devices. With these changes sending a control command packet to the indoor AC unit should always be successful. This addresses issue #102.

A summary of the changes:
- Adds support for registering the ESPHome device as a Non-NASA controller.
- Adds support for waking indoor/outdoor devices if they are in a sleep state, prior to sending a control command.
- Adds support for detecting whether sending a control command was successful, and resending it automatically if required.
- Adds a new "keepalive" option for preventing Non-NASA devices from sleeping. This option is off by default. Enabling this option will allow you to track values like indoor and outdoor temperature even when the AC isn't in use.
- Resolves issue with the UART packet parsing logic that could cause a number of valid Non-NASA packets to be lost after a packet parsing error occurs (such as a failed CRC check).

These changes have been tested against two Non-NASA devices: a AQV30UW and a AQV18UW. Both setups only have a single indoor unit, so it's worth testing these changes in environments that have two or more units. It's also worth testing these changes in an environment with NASA units, to ensure the packet parsing changes haven't inadvertently caused any issues.