### PR TITLE
Update readme.md - NonNASA add AJ050NCJ2EG

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ In generel all devices with dedicated communication wires (not only power) shoul
 
 #### NonNASA
 
-- RJ100F5HXBA,
+- RJ100F5HXBA, AJ050NCJ2EG
 
 ### Dont work
 


### PR DESCRIPTION
NonNASA support list: add AJ050NCJ2EG

I've been using this with AJ050NCJ2EG for a long time now and after the fixes discussed at https://github.com/lanwin/esphome_samsung_ac/issues/59 it has been stable for me.

Thanks.