### PR TITLE
[NASA] Add Automatic Cleaning mode for Samsung AC.

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -55,6 +55,8 @@ CONF_DEVICE_ROOM_TEMPERATURE_OFFSET = "room_temperature_offset"
 CONF_DEVICE_TARGET_TEMPERATURE = "target_temperature"
 CONF_DEVICE_WATER_OUTLET_TARGET = "water_outlet_target"
 CONF_DEVICE_OUTDOOR_TEMPERATURE = "outdoor_temperature"
+CONF_DEVICE_INDOOR_EVA_IN_TEMPERATURE = "indoor_eva_in_temperature"
+CONF_DEVICE_INDOOR_EVA_OUT_TEMPERATURE = "indoor_eva_out_temperature"
 CONF_DEVICE_WATER_TEMPERATURE = "water_temperature"
 CONF_DEVICE_WATER_TARGET_TEMPERATURE = "water_target_temperature"
 CONF_DEVICE_POWER = "power"
@@ -174,6 +176,18 @@ DEVICE_SCHEMA = (
             ),
             cv.Optional(CONF_DEVICE_ROOM_TEMPERATURE_OFFSET): cv.float_,
             cv.Optional(CONF_DEVICE_OUTDOOR_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+             cv.Optional(CONF_DEVICE_INDOOR_EVA_IN_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+             cv.Optional(CONF_DEVICE_INDOOR_EVA_OUT_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -316,6 +316,16 @@ async def to_code(config):
             conf = device[CONF_DEVICE_OUTDOOR_TEMPERATURE]
             sens = await sensor.new_sensor(conf)
             cg.add(var_dev.set_outdoor_temperature_sensor(sens))
+            
+        if CONF_DEVICE_INDOOR_EVA_IN_TEMPERATURE in device:
+            conf = device[CONF_DEVICE_INDOOR_EVA_IN_TEMPERATURE]
+            sens = await sensor.new_sensor(conf)
+            cg.add(var_dev.set_indoor_eva_in_temperature_sensor(sens))
+            
+        if CONF_DEVICE_INDOOR_EVA_OUT_TEMPERATURE in device:
+            conf = device[CONF_DEVICE_INDOOR_EVA_OUT_TEMPERATURE]
+            sens = await sensor.new_sensor(conf)
+            cg.add(var_dev.set_indoor_eva_out_temperature_sensor(sens))
 
         if CONF_DEVICE_WATER_TARGET_TEMPERATURE in device:
             conf = device[CONF_DEVICE_WATER_TARGET_TEMPERATURE]

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -60,6 +60,7 @@ CONF_DEVICE_INDOOR_EVA_OUT_TEMPERATURE = "indoor_eva_out_temperature"
 CONF_DEVICE_WATER_TEMPERATURE = "water_temperature"
 CONF_DEVICE_WATER_TARGET_TEMPERATURE = "water_target_temperature"
 CONF_DEVICE_POWER = "power"
+CONF_DEVICE_AUTOMATIC_CLEANING = "automatic_cleaning"
 CONF_DEVICE_WATER_HEATER_POWER = "water_heater_power"
 CONF_DEVICE_MODE = "mode"
 CONF_DEVICE_CLIMATE = "climate"
@@ -197,6 +198,7 @@ DEVICE_SCHEMA = (
             cv.Optional(CONF_DEVICE_WATER_OUTLET_TARGET): NUMBER_SCHEMA,
             cv.Optional(CONF_DEVICE_WATER_TARGET_TEMPERATURE): NUMBER_SCHEMA,
             cv.Optional(CONF_DEVICE_POWER): switch.switch_schema(Samsung_AC_Switch),
+            cv.Optional(CONF_DEVICE_AUTOMATIC_CLEANING): switch.switch_schema(Samsung_AC_Switch),
             cv.Optional(CONF_DEVICE_WATER_HEATER_POWER): switch.switch_schema(Samsung_AC_Switch),
             cv.Optional(CONF_DEVICE_MODE): SELECT_MODE_SCHEMA,
             cv.Optional(CONF_DEVICE_CLIMATE): CLIMATE_SCHEMA,
@@ -314,6 +316,11 @@ async def to_code(config):
             conf = device[CONF_DEVICE_POWER]
             sens = await switch.new_switch(conf)
             cg.add(var_dev.set_power_switch(sens))
+        
+        if CONF_DEVICE_AUTOMATIC_CLEANING in device:
+            conf = device[CONF_DEVICE_AUTOMATIC_CLEANING]
+            sens = await switch.new_switch(conf)
+            cg.add(var_dev.set_automatic_cleaning_switch(sens))
         
         if CONF_DEVICE_WATER_HEATER_POWER in device:
             conf = device[CONF_DEVICE_WATER_HEATER_POWER]

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -212,6 +212,8 @@ CONF_DEBUG_LOG_MESSAGES_RAW = "debug_log_messages_raw"
 
 CONF_NON_NASA_KEEPALIVE = "non_nasa_keepalive"
 
+CONF_LOG_UNDEFINED_MESSAGES = "log_undefined_messages"
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -224,6 +226,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_DEBUG_LOG_MESSAGES, default=False): cv.boolean,
             cv.Optional(CONF_DEBUG_LOG_MESSAGES_RAW, default=False): cv.boolean,
             cv.Optional(CONF_NON_NASA_KEEPALIVE, default=False): cv.boolean,
+            cv.Optional(CONF_LOG_UNDEFINED_MESSAGES, default=False): cv.boolean,
             cv.Optional(CONF_CAPABILITIES): CAPABILITIES_SCHEMA,
             cv.Required(CONF_DEVICES): cv.ensure_list(DEVICE_SCHEMA),
         }
@@ -387,6 +390,9 @@ async def to_code(config):
             
     if (CONF_NON_NASA_KEEPALIVE in config):
         cg.add(var.set_non_nasa_keepalive(config[CONF_NON_NASA_KEEPALIVE]))
+        
+    if (CONF_LOG_UNDEFINED_MESSAGES in config):
+        cg.add(var.set_log_undefined_messages(config[CONF_LOG_UNDEFINED_MESSAGES]))
 
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -228,6 +228,8 @@ CONF_NON_NASA_KEEPALIVE = "non_nasa_keepalive"
 
 CONF_LOG_UNDEFINED_MESSAGES = "log_undefined_messages"
 
+CONF_LOG_MESSAGES = "log_messages"
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -241,6 +243,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_DEBUG_LOG_MESSAGES_RAW, default=False): cv.boolean,
             cv.Optional(CONF_NON_NASA_KEEPALIVE, default=False): cv.boolean,
             cv.Optional(CONF_LOG_UNDEFINED_MESSAGES, default=False): cv.boolean,
+            cv.Optional(CONF_LOG_MESSAGES, default=False): cv.boolean,
             cv.Optional(CONF_CAPABILITIES): CAPABILITIES_SCHEMA,
             cv.Required(CONF_DEVICES): cv.ensure_list(DEVICE_SCHEMA),
         }
@@ -417,6 +420,9 @@ async def to_code(config):
         
     if (CONF_LOG_UNDEFINED_MESSAGES in config):
         cg.add(var.set_log_undefined_messages(config[CONF_LOG_UNDEFINED_MESSAGES]))
+
+    if (CONF_LOG_MESSAGES in config):
+        cg.add(var.set_log_messages(config[CONF_LOG_MESSAGES]))
 
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/components/samsung_ac/protocol.cpp
+++ b/components/samsung_ac/protocol.cpp
@@ -11,6 +11,7 @@ namespace esphome
         bool debug_log_packets = false;
         bool debug_log_raw_bytes = false;
         bool non_nasa_keepalive = false;
+        bool log_undefined_messages = false;
         ProtocolProcessing protocol_processing = ProtocolProcessing::Auto;
 
         // This functions is designed to run after a new value was added

--- a/components/samsung_ac/protocol.cpp
+++ b/components/samsung_ac/protocol.cpp
@@ -12,6 +12,7 @@ namespace esphome
         bool debug_log_raw_bytes = false;
         bool non_nasa_keepalive = false;
         bool log_undefined_messages = false;
+        bool log_messages = false;
         ProtocolProcessing protocol_processing = ProtocolProcessing::Auto;
 
         // This functions is designed to run after a new value was added

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -11,7 +11,7 @@ namespace esphome
         extern bool debug_log_packets;
         extern bool debug_log_raw_bytes;
         extern bool non_nasa_keepalive;
-        extern bool log_undefined_messages ;
+        extern bool log_undefined_messages;
 
         enum class DecodeResult
         {

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -73,6 +73,8 @@ namespace esphome
             virtual void set_target_temperature(const std::string address, float value) = 0;
             virtual void set_water_outlet_target(const std::string address, float value) = 0;
             virtual void set_outdoor_temperature(const std::string address, float value) = 0;
+            virtual void set_indoor_eva_in_temperature(const std::string address, float value) = 0;
+            virtual void set_indoor_eva_out_temperature(const std::string address, float value) = 0;
             virtual void set_target_water_temperature(const std::string address, float value) = 0;
             virtual void set_mode(const std::string address, Mode mode) = 0;
             virtual void set_fanmode(const std::string address, FanMode fanmode) = 0;

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -11,6 +11,7 @@ namespace esphome
         extern bool debug_log_packets;
         extern bool debug_log_raw_bytes;
         extern bool non_nasa_keepalive;
+        extern bool log_undefined_messages ;
 
         enum class DecodeResult
         {

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -69,6 +69,7 @@ namespace esphome
             virtual void publish_data(std::vector<uint8_t> &data) = 0;
             virtual void register_address(const std::string address) = 0;
             virtual void set_power(const std::string address, bool value) = 0;
+            virtual void set_automatic_cleaning(const std::string address, bool value) = 0;
             virtual void set_water_heater_power(const std::string address, bool value) = 0;
             virtual void set_room_temperature(const std::string address, float value) = 0;
             virtual void set_target_temperature(const std::string address, float value) = 0;
@@ -90,6 +91,7 @@ namespace esphome
         {
         public:
             optional<bool> power;
+            optional<bool> automatic_cleaning;
             optional<bool> water_heater_power;
             optional<Mode> mode;
             optional<float> target_temp;

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -12,6 +12,7 @@ namespace esphome
         extern bool debug_log_raw_bytes;
         extern bool non_nasa_keepalive;
         extern bool log_undefined_messages;
+        extern bool log_messages;
 
         enum class DecodeResult
         {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -595,6 +595,18 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             target->set_outdoor_temperature(source, temp);
             break;
         }
+        case MessageNumber::VAR_IN_TEMP_EVA_IN_F: {
+            double temp = ((int16_t)message.value) / 10.0;
+            ESP_LOGW(TAG, "s:%s d:%s VAR_IN_TEMP_EVA_IN_F %li", source.c_str(), dest.c_str(), message.value);
+            target->set_indoor_eva_in_temperature(source, temp);
+            break;
+        }
+        case MessageNumber::VAR_OUT_TEMP_EVA_IN_F: {
+            double temp = ((int16_t)message.value) / 10.0;
+            ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_TEMP_EVA_IN_F %li", source.c_str(), dest.c_str(), message.value);
+            target->set_indoor_eva_out_temperature(source, temp);
+            break;
+        }
         default:
 		if (log_undefined_messages)
                 {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -670,7 +670,7 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             optional<std::set<uint16_t>> custom = target->get_custom_sensors(source);
             for (auto &message : packet_.messages)
             {
-                process_messageset(source, dest, message, custom, target);
+                process_messageset(source, dest, message, custom, target,this->log_undefined_messages_);
             }
         }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -386,6 +386,13 @@ namespace esphome
                 power.value = request.power.value() ? 1 : 0;
                 packet.messages.push_back(power);
             }
+			
+			if (request.automatic_cleaning)
+            {
+                MessageSet automatic_cleaning(MessageNumber::ENUM_in_operation_automatic_cleaning);
+                automatic_cleaning.value = request.automatic_cleaning.value() ? 1 : 0;
+                packet.messages.push_back(automatic_cleaning);
+            }
 
             if (request.water_heater_power)
             {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -566,6 +566,10 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
            if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");}
             target->set_power(source, message.value != 0);
             break;
+        case MessageNumber::ENUM_in_operation_automatic_cleaning:
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_automatic_cleaning %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");}
+            target->set_automatic_cleaning(source, message.value != 0);
+            break;
         case MessageNumber::ENUM_in_water_heater_power:
            if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");}
             target->set_water_heater_power(source, message.value != 0);

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -530,87 +530,87 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
     switch (message.messageNumber) {
         case MessageNumber::VAR_in_temp_room_f: {
             double temp = message.value / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_room_f %f", source.c_str(), dest.c_str(), temp);
+			if(log_messages){ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_room_f %f", source.c_str(), dest.c_str(), temp);}
             target->set_room_temperature(source, temp);
             break;
         }
         case MessageNumber::VAR_in_temp_target_f: {
             double temp = message.value / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_target_f %f", source.c_str(), dest.c_str(), temp);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_target_f %f", source.c_str(), dest.c_str(), temp);}
             target->set_target_temperature(source, temp);
             break;
         }
         case MessageNumber::VAR_in_temp_water_outlet_target_f: {
             double temp = message.value / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_outlet_target_f %f", source.c_str(), dest.c_str(), temp);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_outlet_target_f %f", source.c_str(), dest.c_str(), temp);}
             target->set_water_outlet_target(source, temp);
             break;
         }
         case MessageNumber::VAR_in_temp_water_heater_target_f: {
             double temp = message.value / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_heater_target_f %f", source.c_str(), dest.c_str(), temp);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_heater_target_f %f", source.c_str(), dest.c_str(), temp);}
             target->set_target_water_temperature(source, temp);
             break;
         }
         case MessageNumber::ENUM_in_state_humidity_percent:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_state_humidity_percent %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_state_humidity_percent %li", source.c_str(), dest.c_str(), message.value);}
             break;
         case MessageNumber::ENUM_in_operation_power:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");}
             target->set_power(source, message.value != 0);
             break;
         case MessageNumber::ENUM_in_water_heater_power:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");}
             target->set_water_heater_power(source, message.value != 0);
             break;
         case MessageNumber::ENUM_in_operation_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode %li", source.c_str(), dest.c_str(), message.value);
+          if(log_messages){  ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode %li", source.c_str(), dest.c_str(), message.value);}
             target->set_mode(source, operation_mode_to_mode(message.value));
             break;
         case MessageNumber::ENUM_in_fan_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode %li", source.c_str(), dest.c_str(), message.value);}
             target->set_fanmode(source, fan_mode_real_to_fanmode(message.value));
             break;
         case MessageNumber::ENUM_in_fan_mode_real:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode_real %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode_real %li", source.c_str(), dest.c_str(), message.value);}
             break;
         case MessageNumber::ENUM_in_alt_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c_str(), dest.c_str(), message.value);
+            if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c_str(), dest.c_str(), message.value);}
             target->set_altmode(source, message.value);
             break;
         case MessageNumber::ENUM_in_louver_hl_swing:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_swing %li", source.c_str(), dest.c_str(), message.value);
+          if(log_messages){  ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_swing %li", source.c_str(), dest.c_str(), message.value);}
             target->set_swing_vertical(source, message.value == 1);
             break;
         case MessageNumber::ENUM_in_louver_lr_swing:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_lr_swing %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_lr_swing %li", source.c_str(), dest.c_str(), message.value);}
             target->set_swing_horizontal(source, message.value == 1);
             break;
         case MessageNumber::VAR_in_temp_water_tank_f:
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_tank_f %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_tank_f %li", source.c_str(), dest.c_str(), message.value);}
             break;
         case MessageNumber::VAR_out_sensor_airout: {
             double temp = ((int16_t)message.value) / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_airout %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_airout %li", source.c_str(), dest.c_str(), message.value);}
             target->set_outdoor_temperature(source, temp);
             break;
         }
         case MessageNumber::VAR_IN_TEMP_EVA_IN_F: {
             double temp = ((int16_t)message.value) / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_IN_TEMP_EVA_IN_F %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_IN_TEMP_EVA_IN_F %li", source.c_str(), dest.c_str(), message.value);}
             target->set_indoor_eva_in_temperature(source, temp);
             break;
         }
         case MessageNumber::VAR_IN_TEMP_EVA_OUT_F: {
             double temp = ((int16_t)message.value) / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_IN_TEMP_EVA_OUT_F %li", source.c_str(), dest.c_str(), message.value);
+           if(log_messages){ ESP_LOGW(TAG, "s:%s d:%s VAR_IN_TEMP_EVA_OUT_F %li", source.c_str(), dest.c_str(), message.value);}
             target->set_indoor_eva_out_temperature(source, temp);
             break;
         }
         default:
 		if (log_undefined_messages)
                 {
-                    ESP_LOGW(TAG, "Tanımsız mesaj s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+                    ESP_LOGW(TAG, "Undefined s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
                 }
             
             break;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1063,12 +1063,21 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             case 0x602:  // STR_ad_option_install_2
             case 0x600:  // STR_ad_option_basic
             case 0x202:  // VAR_ad_error_code1
+			
             case 0x42d1: // VAR_IN_DUST_SENSOR_PM10_0_VALUE
+			{
+               ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM10_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+               return; // Ingore cause not important
+            }
             case 0x42d2: // VAR_IN_DUST_SENSOR_PM2_5_VALUE
+			{
+               ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM2_5_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+               return; // Ingore cause not important
+            }
             case 0x42d3: // VAR_IN_DUST_SENSOR_PM1_0_VALUE
             {
-                // ESP_LOGW(TAG, "s:%s d:%s Ignore %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
-                return; // Ingore cause not important
+               ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM1_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+               return; // Ingore cause not important
             }
 
             case 0x23:

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -601,9 +601,9 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             target->set_indoor_eva_in_temperature(source, temp);
             break;
         }
-        case MessageNumber::VAR_OUT_TEMP_EVA_IN_F: {
+        case MessageNumber::VAR_IN_TEMP_EVA_OUT_F: {
             double temp = ((int16_t)message.value) / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_TEMP_EVA_IN_F %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_IN_TEMP_EVA_OUT_F %li", source.c_str(), dest.c_str(), message.value);
             target->set_indoor_eva_out_temperature(source, temp);
             break;
         }

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -502,7 +502,7 @@ namespace esphome
             }
         }
 
-void process_messageset(std::string source, std::string dest, MessageSet &message, optional<std::set<uint16_t>> &custom, MessageTarget *target) {
+void process_messageset(std::string source, std::string dest, MessageSet &message, optional<std::set<uint16_t>> &custom, MessageTarget *target, bool log_undefined_messages) {
     if (debug_mqtt_connected()) {
         std::string topic_prefix = "samsung_ac/nasa/";
         std::string topic_suffix = long_to_hex((uint16_t)message.messageNumber);
@@ -548,7 +548,7 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
         }
         case MessageNumber::VAR_in_temp_water_heater_target_f: {
             double temp = message.value / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_heater_target_f %f", source.c_str(), dest.c_str(), temp);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_heater_target_f %f", source.c_str(), dest.c.str(), temp);
             target->set_target_water_temperature(source, temp);
             break;
         }
@@ -556,50 +556,53 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             ESP_LOGW(TAG, "s:%s d:%s ENUM_in_state_humidity_percent %li", source.c_str(), dest.c_str(), message.value);
             break;
         case MessageNumber::ENUM_in_operation_power:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c.str(), dest.c.str(), message.value == 0 ? "off" : "on");
             target->set_power(source, message.value != 0);
             break;
         case MessageNumber::ENUM_in_water_heater_power:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c.str(), dest.c.str(), message.value == 0 ? "off" : "on");
             target->set_water_heater_power(source, message.value != 0);
             break;
         case MessageNumber::ENUM_in_operation_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode %li", source.c.str(), dest.c.str(), message.value);
             target->set_mode(source, operation_mode_to_mode(message.value));
             break;
         case MessageNumber::ENUM_in_fan_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode %li", source.c.str(), dest.c.str(), message.value);
             target->set_fanmode(source, fan_mode_real_to_fanmode(message.value));
             break;
         case MessageNumber::ENUM_in_fan_mode_real:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode_real %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode_real %li", source.c.str(), dest.c.str(), message.value);
             break;
         case MessageNumber::ENUM_in_alt_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c.str(), dest.c.str(), message.value);
             target->set_altmode(source, message.value);
             break;
         case MessageNumber::ENUM_in_louver_hl_swing:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_swing %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_swing %li", source.c.str(), dest.c.str(), message.value);
             target->set_swing_vertical(source, message.value == 1);
             break;
         case MessageNumber::ENUM_in_louver_lr_swing:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_lr_swing %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_lr_swing %li", source.c.str(), dest.c.str(), message.value);
             target->set_swing_horizontal(source, message.value == 1);
             break;
         case MessageNumber::VAR_in_temp_water_tank_f:
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_tank_f %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_tank_f %li", source.c.str(), dest.c.str(), message.value);
             break;
         case MessageNumber::VAR_out_sensor_airout: {
             double temp = ((int16_t)message.value) / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_airout %li", source.c_str(), dest.c_str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_airout %li", source.c.str(), dest.c.str(), message.value);
             target->set_outdoor_temperature(source, temp);
             break;
         }
         default:
-            ESP_LOGW(TAG, "Tanımsız mesaj s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+            if (log_undefined_messages) {
+                ESP_LOGW(TAG, "Tanımsız mesaj s:%s d:%s %s", source.c.str(), dest.c.str(), message.to_string().c.str());
+            }
             break;
     }
 }
+
 
 
         DecodeResult try_decode_nasa_packet(std::vector<uint8_t> data)

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -502,7 +502,7 @@ namespace esphome
             }
         }
 
-void process_messageset(std::string source, std::string dest, MessageSet &message, optional<std::set<uint16_t>> &custom, MessageTarget *target, bool log_undefined_messages) {
+void process_messageset(std::string source, std::string dest, MessageSet &message, optional<std::set<uint16_t>> &custom, MessageTarget *target) {
     if (debug_mqtt_connected()) {
         std::string topic_prefix = "samsung_ac/nasa/";
         std::string topic_suffix = long_to_hex((uint16_t)message.messageNumber);
@@ -548,7 +548,7 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
         }
         case MessageNumber::VAR_in_temp_water_heater_target_f: {
             double temp = message.value / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_heater_target_f %f", source.c_str(), dest.c.str(), temp);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_heater_target_f %f", source.c_str(), dest.c_str(), temp);
             target->set_target_water_temperature(source, temp);
             break;
         }
@@ -556,53 +556,54 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             ESP_LOGW(TAG, "s:%s d:%s ENUM_in_state_humidity_percent %li", source.c_str(), dest.c_str(), message.value);
             break;
         case MessageNumber::ENUM_in_operation_power:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c.str(), dest.c.str(), message.value == 0 ? "off" : "on");
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");
             target->set_power(source, message.value != 0);
             break;
         case MessageNumber::ENUM_in_water_heater_power:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c.str(), dest.c.str(), message.value == 0 ? "off" : "on");
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_water_heater_power %s", source.c_str(), dest.c_str(), message.value == 0 ? "off" : "on");
             target->set_water_heater_power(source, message.value != 0);
             break;
         case MessageNumber::ENUM_in_operation_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode %li", source.c_str(), dest.c_str(), message.value);
             target->set_mode(source, operation_mode_to_mode(message.value));
             break;
         case MessageNumber::ENUM_in_fan_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode %li", source.c_str(), dest.c_str(), message.value);
             target->set_fanmode(source, fan_mode_real_to_fanmode(message.value));
             break;
         case MessageNumber::ENUM_in_fan_mode_real:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode_real %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_mode_real %li", source.c_str(), dest.c_str(), message.value);
             break;
         case MessageNumber::ENUM_in_alt_mode:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_alt_mode %li", source.c_str(), dest.c_str(), message.value);
             target->set_altmode(source, message.value);
             break;
         case MessageNumber::ENUM_in_louver_hl_swing:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_swing %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_swing %li", source.c_str(), dest.c_str(), message.value);
             target->set_swing_vertical(source, message.value == 1);
             break;
         case MessageNumber::ENUM_in_louver_lr_swing:
-            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_lr_swing %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_lr_swing %li", source.c_str(), dest.c_str(), message.value);
             target->set_swing_horizontal(source, message.value == 1);
             break;
         case MessageNumber::VAR_in_temp_water_tank_f:
-            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_tank_f %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_water_tank_f %li", source.c_str(), dest.c_str(), message.value);
             break;
         case MessageNumber::VAR_out_sensor_airout: {
             double temp = ((int16_t)message.value) / 10.0;
-            ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_airout %li", source.c.str(), dest.c.str(), message.value);
+            ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_airout %li", source.c_str(), dest.c_str(), message.value);
             target->set_outdoor_temperature(source, temp);
             break;
         }
         default:
-            if (log_undefined_messages) {
-                ESP_LOGW(TAG, "Tanımsız mesaj s:%s d:%s %s", source.c.str(), dest.c.str(), message.to_string().c.str());
-            }
+		if (log_undefined_messages)
+                {
+                    ESP_LOGW(TAG, "Tanımsız mesaj s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+                }
+            
             break;
     }
 }
-
 
 
         DecodeResult try_decode_nasa_packet(std::vector<uint8_t> data)
@@ -670,7 +671,7 @@ void process_messageset(std::string source, std::string dest, MessageSet &messag
             optional<std::set<uint16_t>> custom = target->get_custom_sensors(source);
             for (auto &message : packet_.messages)
             {
-                process_messageset(source, dest, message, custom, target,this->log_undefined_messages_);
+                process_messageset(source, dest, message, custom, target);
             }
         }
 

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -85,8 +85,8 @@ namespace esphome
             VAR_in_temp_water_tank_f = 0x4237,
             VAR_out_sensor_airout = 0x8204,
             VAR_in_temp_water_heater_target_f = 0x4235,
-            VAR_IN_TEMP_EVA_IN_F= 0x4205,
-            VAR_IN_TEMP_EVA_OUT_F= 0x4206,
+            VAR_IN_TEMP_EVA_IN_F = 0x4205,
+            VAR_IN_TEMP_EVA_OUT_F = 0x4206,
         };
 
         struct Address

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -71,6 +71,7 @@ namespace esphome
         {
             Undefiend = 0,
             ENUM_in_operation_power = 0x4000,
+            ENUM_in_operation_automatic_cleaning = 0x4111,
             ENUM_in_water_heater_power = 0x4065,
             ENUM_in_operation_mode = 0x4001,
             ENUM_in_fan_mode = 0x4006, // Did not exists in xml...only in Remocon.dll code

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -85,6 +85,8 @@ namespace esphome
             VAR_in_temp_water_tank_f = 0x4237,
             VAR_out_sensor_airout = 0x8204,
             VAR_in_temp_water_heater_target_f = 0x4235,
+            VAR_IN_TEMP_EVA_IN_F= 0x4205,
+            VAR_IN_TEMP_EVA_OUT_F= 0x4206,
         };
 
         struct Address

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -11,7 +11,6 @@ namespace esphome
     void Samsung_AC::setup()
     {
       ESP_LOGW(TAG, "setup");
-	  this->log_undefined_messages_ = this->get_or_create("log_undefined_messages", false);
     }
 
     void Samsung_AC::update()

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -11,6 +11,7 @@ namespace esphome
     void Samsung_AC::setup()
     {
       ESP_LOGW(TAG, "setup");
+	  this->log_undefined_messages_ = this->get_or_create("log_undefined_messages", false);
     }
 
     void Samsung_AC::update()

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -55,6 +55,10 @@ void set_log_undefined_messages (bool value)
       {
         log_undefined_messages = value;
       }
+	  void set_log_messages (bool value)
+      {
+        log_messages = value;
+      }
       void register_device(Samsung_AC_Device *device);
 
       void /*MessageTarget::*/ register_address(const std::string address) override

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -128,6 +128,12 @@ void set_log_undefined_messages (bool value)
         if (dev != nullptr)
           dev->update_power(value);
       }
+      void /*MessageTarget::*/ set_automatic_cleaning(const std::string address, bool value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_automatic_cleaning(value);
+      }
       void /*MessageTarget::*/ set_water_heater_power(const std::string address, bool value) override
       {
         Samsung_AC_Device *dev = find_device(address);

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -51,12 +51,10 @@ namespace esphome
       {
         non_nasa_keepalive = value;
       }
-
-	  void set_log_undefined_messages(bool value)
-  {
-    log_undefined_messages_ = value;
-  }
-	  
+void set_log_undefined_messages (bool value)
+      {
+        log_undefined_messages = value;
+      }
       void register_device(Samsung_AC_Device *device);
 
       void /*MessageTarget::*/ register_address(const std::string address) override
@@ -170,7 +168,6 @@ namespace esphome
       }
 
     protected:
-	  bool log_undefined_messages_{false};
       Samsung_AC_Device *find_device(const std::string address)
       {
         auto it = devices_.find(address);

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -83,6 +83,20 @@ void set_log_undefined_messages (bool value)
           dev->update_outdoor_temperature(value);
       }
 
+      void /*MessageTarget::*/ set_indoor_eva_in_temperature(const std::string address, float value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_indoor_eva_in_temperature(value);
+      }
+
+      void /*MessageTarget::*/ set_indoor_eva_out_temperature(const std::string address, float value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_indoor_eva_out_temperature(value);
+      }
+
       void /*MessageTarget::*/ set_target_temperature(const std::string address, float value) override
       {
         Samsung_AC_Device *dev = find_device(address);

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -52,10 +52,10 @@ namespace esphome
         non_nasa_keepalive = value;
       }
 
-	  void log_undefined_messages(bool value)
-      {
-        log_undefined_messages = value;
-      }
+	  void set_log_undefined_messages(bool value)
+  {
+    log_undefined_messages_ = value;
+  }
 	  
       void register_device(Samsung_AC_Device *device);
 
@@ -170,6 +170,7 @@ namespace esphome
       }
 
     protected:
+	  bool log_undefined_messages_{false};
       Samsung_AC_Device *find_device(const std::string address)
       {
         auto it = devices_.find(address);

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -52,6 +52,11 @@ namespace esphome
         non_nasa_keepalive = value;
       }
 
+	  void log_undefined_messages(bool value)
+      {
+        log_undefined_messages = value;
+      }
+	  
       void register_device(Samsung_AC_Device *device);
 
       void /*MessageTarget::*/ register_address(const std::string address) override

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -108,17 +108,17 @@ namespace esphome
 
       void set_outdoor_temperature_sensor(sensor::Sensor *sensor)
       {
-        indoor_eva_in_temperature = sensor;
+		  outdoor_temperature = sensor;
       }
 
       void set_indoor_eva_in_temperature_sensor(sensor::Sensor *sensor)
       {
-        indoor_eva_out_temperature = sensor;
+		  indoor_eva_in_temperature = sensor;
       }
 
       void set_indoor_eva_out_temperature_sensor(sensor::Sensor *sensor)
       {
-        outdoor_temperature = sensor;
+        indoor_eva_out_temperature = sensor;
       }
 
       void add_custom_sensor(int message_number, sensor::Sensor *sensor)

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -95,6 +95,7 @@ namespace esphome
       Samsung_AC_Number *water_outlet_target{nullptr};
       Samsung_AC_Number *target_water_temperature{nullptr};
       Samsung_AC_Switch *power{nullptr};
+      Samsung_AC_Switch *automatic_cleaning{nullptr};
       Samsung_AC_Switch *water_heater_power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Climate *climate{nullptr};
@@ -144,6 +145,17 @@ namespace esphome
         {
           ProtocolRequest request;
           request.power = value;
+          publish_request(request);
+        };
+      }
+	  
+void set_automatic_cleaning_switch(Samsung_AC_Switch *switch_)
+      {
+        automatic_cleaning = switch_;
+        automatic_cleaning->write_state_ = [this](bool value)
+        {
+          ProtocolRequest request;
+          request.automatic_cleaning = value;
           publish_request(request);
         };
       }
@@ -233,6 +245,7 @@ namespace esphome
       }
 
       optional<bool> _cur_power;
+      optional<bool> _cur_automatic_cleaning;
       optional<bool> _cur_water_heater_power;
       optional<Mode> _cur_mode;
 
@@ -241,6 +254,15 @@ namespace esphome
         _cur_power = value;
         if (power != nullptr)
           power->publish_state(value);
+        if (climate != nullptr)
+          calc_and_publish_mode();
+      }
+	  
+void update_automatic_cleaning(bool value)
+      {
+        _cur_automatic_cleaning = value;
+        if (automatic_cleaning != nullptr)
+          automatic_cleaning->publish_state(value);
         if (climate != nullptr)
           calc_and_publish_mode();
       }

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -89,6 +89,8 @@ namespace esphome
       std::string address;
       sensor::Sensor *room_temperature{nullptr};
       sensor::Sensor *outdoor_temperature{nullptr};
+	  sensor::Sensor *indoor_eva_in_temperature{nullptr};
+	  sensor::Sensor *indoor_eva_out_temperature{nullptr};
       Samsung_AC_Number *target_temperature{nullptr};
       Samsung_AC_Number *water_outlet_target{nullptr};
       Samsung_AC_Number *target_water_temperature{nullptr};
@@ -105,6 +107,16 @@ namespace esphome
       }
 
       void set_outdoor_temperature_sensor(sensor::Sensor *sensor)
+      {
+        indoor_eva_in_temperature = sensor;
+      }
+
+      void set_indoor_eva_in_temperature_sensor(sensor::Sensor *sensor)
+      {
+        indoor_eva_out_temperature = sensor;
+      }
+
+      void set_indoor_eva_out_temperature_sensor(sensor::Sensor *sensor)
       {
         outdoor_temperature = sensor;
       }
@@ -331,6 +343,18 @@ namespace esphome
       {
         if (outdoor_temperature != nullptr)
           outdoor_temperature->publish_state(value);
+      }
+
+      void update_indoor_eva_in_temperature(float value)
+      {
+        if (indoor_eva_in_temperature != nullptr)
+          indoor_eva_in_temperature->publish_state(value);
+      }
+
+      void update_indoor_eva_out_temperature(float value)
+      {
+        if (indoor_eva_out_temperature != nullptr)
+          indoor_eva_out_temperature->publish_state(value);
       }
 
       void update_custom_sensor(uint16_t message_number, float value)

--- a/example.yaml
+++ b/example.yaml
@@ -47,7 +47,7 @@ uart:
 
 # Import custom component from GitHub
 external_components:
-  - source: github://lanwin/esphome_samsung_ac@stable # use @main if you want the latest development (possibly unstable?)
+  - source: github://omerfaruk-aran/esphome_samsung_ac@new_test # use @main if you want the latest development (possibly unstable?)
     components: [samsung_ac]
 
 # Configuration of AC component
@@ -56,6 +56,12 @@ samsung_ac:
   # For NonNASA devices the following option can be enabled to prevent the device from sleeping when idle. This allows
   # values like internal and external temperature to continue to be tracked when the device isn't in use.
   non_nasa_keepalive: true
+  
+  #When enabled (set to true), this option will log the messages associated with undefined codes on the device. This is useful for debugging and identifying any unexpected or unknown codes that the device may receive during operation.
+  log_undefined_messages: false
+  
+  #When enabled (set to true), this option logs messages associated with defined codes on the device. This helps in monitoring the behavior of the device by recording the activity related to known, expected codes.
+  log_messages: false
 
   # Capabilities configure the features alle devices of your AC system have (all parts of this section are optional). 
   # All capabilities are off by default, you need to enable only those your devices have.
@@ -104,6 +110,8 @@ samsung_ac:
         name: "Kitchen power"
       mode:
         name: "Kitchen mode"
+      automatic_cleaning:
+        name: "Kitchen automatic clean"
 
       # If your AC sits near or inside the ceiling, the reported room temperature is often a little bit heigher then whats 
       # measured below. This property can be used to correct that value.

--- a/example.yaml
+++ b/example.yaml
@@ -110,6 +110,10 @@ samsung_ac:
         name: "Kitchen power"
       mode:
         name: "Kitchen mode"
+        
+        #Add automatic_cleaning mode for Samsung AC NASA
+            #- Added the "automatic_cleaning" feature to the Samsung AC integration.
+            #- This mode ensures hygienic drying of all moisture in the indoor unit after the cooling process is completed.
       automatic_cleaning:
         name: "Kitchen automatic clean"
 

--- a/test/esphome/core/log.h
+++ b/test/esphome/core/log.h
@@ -22,18 +22,14 @@ namespace esphome
         printf((str.c_str()), ##__VA_ARGS__); \
     } while (0);
 
-#define ESP_LOGW(tag, format, ...)                            \
-    do                                                        \
-    {                                                         \
-        if (log_messages)                                     \
-        {                                                     \
-            std::string str = "";                             \
-            str += format;                                    \
-            str += "\n";                                      \
-            printf((str.c_str()), ##__VA_ARGS__);             \
-        }                                                     \
-    } while (0)
-
+#define ESP_LOGW(tag, format, ...)            \
+    do                                        \
+    {                                         \
+        std::string str = "";                 \
+        str += format;                        \
+        str += "\n";                          \
+        printf((str.c_str()), ##__VA_ARGS__); \
+    } while (0);
 
 #define ESP_LOGV(tag, format, ...)            \
     do                                        \

--- a/test/esphome/core/log.h
+++ b/test/esphome/core/log.h
@@ -22,14 +22,18 @@ namespace esphome
         printf((str.c_str()), ##__VA_ARGS__); \
     } while (0);
 
-#define ESP_LOGW(tag, format, ...)            \
-    do                                        \
-    {                                         \
-        std::string str = "";                 \
-        str += format;                        \
-        str += "\n";                          \
-        printf((str.c_str()), ##__VA_ARGS__); \
-    } while (0);
+#define ESP_LOGW(tag, format, ...)                            \
+    do                                                        \
+    {                                                         \
+        if (log_messages)                                     \
+        {                                                     \
+            std::string str = "";                             \
+            str += format;                                    \
+            str += "\n";                                      \
+            printf((str.c_str()), ##__VA_ARGS__);             \
+        }                                                     \
+    } while (0)
+
 
 #define ESP_LOGV(tag, format, ...)            \
     do                                        \


### PR DESCRIPTION
This pull request adds the automatic cleaning mode to the Samsung AC integration.

**- Resolves #121**

The automatic cleaning mode ensures hygienic drying of all moisture in the indoor unit after the cooling process is completed.

**Additional Features:**

- Added two new parameters: log_messages and log_undefined_messages.

- log_messages: Enables logging of messages. When set to true, all defined log messages will be recorded.

- log_undefined_messages: Allows logging of undefined messages. When set to true, any undefined messages will be logged for further analysis.

**If both log_messages and log_undefined_messages are set to false, you will only see logs for the functions that you execute through SmartThings. This approach allows you to easily add new features without cluttering the logs with unnecessary information.**

