### PR TITLE
Add Automatic Cleaning Mode and Logging Features to Samsung AC Integration

### DIFF
--- a/components/samsung_ac/protocol.cpp
+++ b/components/samsung_ac/protocol.cpp
@@ -8,9 +8,11 @@ namespace esphome
 {
     namespace samsung_ac
     {
-        bool debug_log_packets = false;
+        //bool debug_log_packets = false;
         bool debug_log_raw_bytes = false;
         bool non_nasa_keepalive = false;
+        bool debug_log_undefined_messages = false;
+		bool debug_log_messages = false;
         ProtocolProcessing protocol_processing = ProtocolProcessing::Auto;
 
         // This functions is designed to run after a new value was added

--- a/components/samsung_ac/protocol.cpp
+++ b/components/samsung_ac/protocol.cpp
@@ -8,11 +8,11 @@ namespace esphome
 {
     namespace samsung_ac
     {
-        //bool debug_log_packets = false;
         bool debug_log_raw_bytes = false;
         bool non_nasa_keepalive = false;
         bool debug_log_undefined_messages = false;
-		bool debug_log_messages = false;
+        bool debug_log_messages = false;
+
         ProtocolProcessing protocol_processing = ProtocolProcessing::Auto;
 
         // This functions is designed to run after a new value was added

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -8,9 +8,11 @@ namespace esphome
 {
     namespace samsung_ac
     {
-        extern bool debug_log_packets;
+        //extern bool debug_log_packets;
         extern bool debug_log_raw_bytes;
         extern bool non_nasa_keepalive;
+        extern bool debug_log_undefined_messages;
+        extern bool debug_log_messages;
 
         enum class DecodeResult
         {
@@ -76,11 +78,14 @@ namespace esphome
             virtual void publish_data(std::vector<uint8_t> &data) = 0;
             virtual void register_address(const std::string address) = 0;
             virtual void set_power(const std::string address, bool value) = 0;
+            virtual void set_automatic_cleaning(const std::string address, bool value) = 0;
             virtual void set_water_heater_power(const std::string address, bool value) = 0;
             virtual void set_room_temperature(const std::string address, float value) = 0;
             virtual void set_target_temperature(const std::string address, float value) = 0;
             virtual void set_water_outlet_target(const std::string address, float value) = 0;
             virtual void set_outdoor_temperature(const std::string address, float value) = 0;
+            virtual void set_indoor_eva_in_temperature(const std::string address, float value) = 0;
+            virtual void set_indoor_eva_out_temperature(const std::string address, float value) = 0;
             virtual void set_target_water_temperature(const std::string address, float value) = 0;
             virtual void set_mode(const std::string address, Mode mode) = 0;
             virtual void set_water_heater_mode(const std::string address, WaterHeaterMode waterheatermode) = 0;
@@ -96,6 +101,7 @@ namespace esphome
         {
         public:
             optional<bool> power;
+            optional<bool> automatic_cleaning;
             optional<bool> water_heater_power;
             optional<Mode> mode;
             optional<WaterHeaterMode> waterheatermode;

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -8,7 +8,6 @@ namespace esphome
 {
     namespace samsung_ac
     {
-        //extern bool debug_log_packets;
         extern bool debug_log_raw_bytes;
         extern bool non_nasa_keepalive;
         extern bool debug_log_undefined_messages;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -911,20 +911,23 @@ namespace esphome
                 break;
 
             case 0x4205: // VAR_in_temp_eva_in_f unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_in_temp_eva_in_f, temp, source, dest);
                 break;
-
+            }
             case 0x4206: // VAR_in_temp_eva_out_f unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_in_temp_eva_out_f, temp, source, dest);
                 break;
-
+            }
             case 0x4211: // VAR_in_capacity_request unit = 'kW'
+            {
                 double temp = (double)message.value / (double)8.6;
                 LOG_MESSAGE(VAR_in_capacity_request, temp, source, dest);
                 break;
-
+            }
             case 0x8001: // ENUM_out_operation_odu_mode
                 // Todo Map
                 LOG_MESSAGE(ENUM_out_operation_odu_mode, message.value, source, dest);
@@ -945,45 +948,53 @@ namespace esphome
                 break;
 
             case 0x8261: // VAR_OUT_SENSOR_PIPEIN3 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN3, temp, source, dest);
                 break;
-
+            }
             case 0x8262: // VAR_OUT_SENSOR_PIPEIN4 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN4, temp, source, dest);
                 break;
-
+            }
             case 0x8263: // VAR_OUT_SENSOR_PIPEIN5 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN5, temp, source, dest);
                 break;
-
+            }
             case 0x8264: // VAR_OUT_SENSOR_PIPEOUT1 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT1, temp, source, dest);
                 break;
-
+            }
             case 0x8265: // VAR_OUT_SENSOR_PIPEOUT2 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT2, temp, source, dest);
                 break;
-
+            }
             case 0x8266: // VAR_OUT_SENSOR_PIPEOUT3 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT3, temp, source, dest);
                 break;
-
+            }
             case 0x8267: // VAR_OUT_SENSOR_PIPEOUT4 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT4, temp, source, dest);
                 break;
-
+            }
             case 0x8268: // VAR_OUT_SENSOR_PIPEOUT5 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT5, temp, source, dest);
                 break;
-
+            }
             case 0x8274: // VAR_out_control_order_cfreq_comp2
                 LOG_MESSAGE(VAR_out_control_order_cfreq_comp2, message.value, source, dest);
                 break;
@@ -1000,10 +1011,11 @@ namespace esphome
                 break;
 
             case 0x8280: // VAR_out_sensor_top1 unit = 'Celsius'
+            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_out_sensor_top1, temp, source, dest);
                 break;
-
+            }
             case 0x82db: // VAR_OUT_PHASE_CURRENT
                 LOG_MESSAGE(VAR_OUT_PHASE_CURRENT, message.value, source, dest);
                 break;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -889,27 +889,6 @@ namespace esphome
                 LOG_MESSAGE(ENUM_in_fan_vent_mode, message.value, source, dest);
                 // fan_vent_mode_to_fanmode();
                 break;
-            case 0x4011: // ENUM_IN_LOUVER_HL_SWING
-            {
-                // Todo Map
-                /*
-               case 0:
-    return 'Off';
-    case 1:
-    return 'On';
-    default:
-    return undefined;
-                */
-                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
-                break;
-            }
-
-            case 0x4012: // ENUM_IN_LOUVER_HL_SWING
-                // Todo Map
-
-                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
-                break;
-
             case 0x4205: // VAR_in_temp_eva_in_f unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
@@ -1057,7 +1036,6 @@ namespace esphome
             case 0x4047:
             case 0x4048:
             case 0x4059:
-            case 0x4060:
             case 0x4074:
             case 0x407d:
             case 0x407e:

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -698,17 +698,17 @@ namespace esphome
                 target->set_outdoor_temperature(source, temp);
                 break;
             }
-            case MessageNumber::VAR_IN_TEMP_EVA_IN_F:
+            case MessageNumber::VAR_in_temp_eva_in_f:
             {
                 double temp = ((int16_t)message.value) / 10.0;
-                LOG_MESSAGE(VAR_IN_TEMP_EVA_IN_F, temp, source, dest);
+                LOG_MESSAGE(VAR_in_temp_eva_in_f, temp, source, dest);
                 target->set_indoor_eva_in_temperature(source, temp);
                 break;
             }
-            case MessageNumber::VAR_IN_TEMP_EVA_OUT_F:
+            case MessageNumber::VAR_in_temp_eva_out_f:
             {
                 double temp = ((int16_t)message.value) / 10.0;
-                LOG_MESSAGE(VAR_IN_TEMP_EVA_OUT_F, temp, source, dest);
+                LOG_MESSAGE(VAR_in_temp_eva_out_f, temp, source, dest);
                 target->set_indoor_eva_out_temperature(source, temp);
                 break;
             }

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -791,7 +791,7 @@ namespace esphome
 
             target->register_address(source);
 
-            LOG_MESSAGE(MSG, packet_.to_string().c_str(), source.c_str(), dest.c_str());
+            LOG_MESSAGE(MSG, packet_.to_string().c_str(), source, dest);
 
             if (packet_.command.dataType == DataType::Ack)
             {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -853,65 +853,42 @@ namespace esphome
             if (source == "20.00.00" || source == "20.00.01" || source == "20.00.03")
                 return;
 
-            if (((uint16_t)message.messageNumber) == 0x4003)
-            {
-                LOG_MESSAGE(ENUM_IN_OPERATION_VENT_POWER, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x4004)
-            {
-                LOG_MESSAGE(ENUM_IN_OPERATION_VENT_MODE, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x4011)
-            {
-                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x4012)
-            {
-                LOG_MESSAGE(ENUM_in_louver_hl_part_swing, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x4060)
-            {
-                LOG_MESSAGE(ENUM_IN_ALTERNATIVE_MODE, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x406E)
-            {
-                LOG_MESSAGE(ENUM_IN_QUIET_MODE, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x4119)
-            {
-                LOG_MESSAGE(ENUM_IN_OPERATION_POWER_ZONE1, message.value, source, dest);
-                break;
-            }
-            if (((uint16_t)message.messageNumber) == 0x411E)
-            {
-                LOG_MESSAGE(ENUM_IN_OPERATION_POWER_ZONE2, message.value, source, dest);
-                break;
-            }
-
             // return; //The use of return here was breaking the code here, I didn't understand why it was breaking it, so I made a temporary comment line.
 
             switch ((uint16_t)message.messageNumber)
             {
+            case 0x4003:
+                LOG_MESSAGE(ENUM_IN_OPERATION_VENT_POWER, message.value, source, dest);
+                break;
+            case 0x4004:
+                LOG_MESSAGE(ENUM_IN_OPERATION_VENT_MODE, message.value, source, dest);
+                break;
+            case == 0x4011:
+                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
+                break;
+            case == 0x4012:
+                LOG_MESSAGE(ENUM_in_louver_hl_part_swing, message.value, source, dest);
+                break;
+            case 0x4060:
+                LOG_MESSAGE(ENUM_IN_ALTERNATIVE_MODE, message.value, source, dest);
+                break;
+            case 0x406E:
+                LOG_MESSAGE(ENUM_IN_QUIET_MODE, message.value, source, dest);
+                break;
+            case 0x4119:
+                LOG_MESSAGE(ENUM_IN_OPERATION_POWER_ZONE1, message.value, source, dest);
+                break;
+            case 0x411E:
+                LOG_MESSAGE(ENUM_IN_OPERATION_POWER_ZONE2, message.value, source, dest);
+                break;
             case 0x4002: // ENUM_in_operation_mode_real
-            {
                 // Todo Map
                 LOG_MESSAGE(ENUM_in_operation_mode_real, message.value, source, dest);
                 break;
-            }
-
             case 0x4008: // ENUM_in_fan_vent_mode
-            {
                 LOG_MESSAGE(ENUM_in_fan_vent_mode, message.value, source, dest);
                 // fan_vent_mode_to_fanmode();
                 break;
-            }
-
             case 0x4011: // ENUM_IN_LOUVER_HL_SWING
             {
                 // Todo Map
@@ -928,152 +905,108 @@ namespace esphome
             }
 
             case 0x4012: // ENUM_IN_LOUVER_HL_SWING
-            {
                 // Todo Map
 
                 LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
                 break;
-            }
 
             case 0x4205: // VAR_in_temp_eva_in_f unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_in_temp_eva_in_f, temp, source, dest);
                 break;
-            }
 
             case 0x4206: // VAR_in_temp_eva_out_f unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_in_temp_eva_out_f, temp, source, dest);
                 break;
-            }
 
             case 0x4211: // VAR_in_capacity_request unit = 'kW'
-            {
                 double temp = (double)message.value / (double)8.6;
                 LOG_MESSAGE(VAR_in_capacity_request, temp, source, dest);
                 break;
-            }
 
             case 0x8001: // ENUM_out_operation_odu_mode
-            {
                 // Todo Map
                 LOG_MESSAGE(ENUM_out_operation_odu_mode, message.value, source, dest);
                 break;
-            }
 
             case 0x8003: // ENUM_out_operation_heatcool
-            {
                 //['Undefined', 'Cool', 'Heat', 'CoolMain', 'HeatMain'];
                 // Todo Map
                 LOG_MESSAGE(ENUM_out_operation_heatcool, message.value, source, dest);
                 break;
-            }
 
             case 0x801a: // ENUM_out_load_4way
-            {
                 LOG_MESSAGE(ENUM_out_load_4way, message.value, source, dest);
                 break;
-            }
 
             case 0x8235: // VAR_out_error_code
-            {
                 LOG_MESSAGE(VAR_out_error_code, message.value, source, dest);
                 break;
-            }
 
             case 0x8261: // VAR_OUT_SENSOR_PIPEIN3 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN3, temp, source, dest);
                 break;
-            }
 
             case 0x8262: // VAR_OUT_SENSOR_PIPEIN4 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN4, temp, source, dest);
                 break;
-            }
 
             case 0x8263: // VAR_OUT_SENSOR_PIPEIN5 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN5, temp, source, dest);
                 break;
-            }
 
             case 0x8264: // VAR_OUT_SENSOR_PIPEOUT1 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT1, temp, source, dest);
                 break;
-            }
 
             case 0x8265: // VAR_OUT_SENSOR_PIPEOUT2 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT2, temp, source, dest);
                 break;
-            }
 
             case 0x8266: // VAR_OUT_SENSOR_PIPEOUT3 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT3, temp, source, dest);
                 break;
-            }
 
             case 0x8267: // VAR_OUT_SENSOR_PIPEOUT4 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT4, temp, source, dest);
                 break;
-            }
 
             case 0x8268: // VAR_OUT_SENSOR_PIPEOUT5 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT5, temp, source, dest);
                 break;
-            }
 
             case 0x8274: // VAR_out_control_order_cfreq_comp2
-            {
                 LOG_MESSAGE(VAR_out_control_order_cfreq_comp2, message.value, source, dest);
                 break;
-            }
             case 0x8275: // VAR_out_control_target_cfreq_comp2
-            {
                 LOG_MESSAGE(VAR_out_control_target_cfreq_comp2, message.value, source, dest);
                 break;
-            }
 
             case 0x82bc: // VAR_OUT_PROJECT_CODE
-            {
                 LOG_MESSAGE(VAR_OUT_PROJECT_CODE, message.value, source, dest);
                 break;
-            }
 
             case 0x82e3: // VAR_OUT_PRODUCT_OPTION_CAPA
-            {
                 LOG_MESSAGE(VAR_OUT_PRODUCT_OPTION_CAPA, message.value, source, dest);
                 break;
-            }
 
             case 0x8280: // VAR_out_sensor_top1 unit = 'Celsius'
-            {
                 double temp = (double)message.value / (double)10;
                 LOG_MESSAGE(VAR_out_sensor_top1, temp, source, dest);
                 break;
-            }
 
             case 0x82db: // VAR_OUT_PHASE_CURRENT
-            {
                 LOG_MESSAGE(VAR_OUT_PHASE_CURRENT, message.value, source, dest);
                 break;
-            }
 
             case 0x402:
             case 0x409:

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -853,7 +853,7 @@ namespace esphome
             if (source == "20.00.00" || source == "20.00.01" || source == "20.00.03")
                 return;
 
-            return; // :)
+            // return; // :)
 
             switch ((uint16_t)message.messageNumber)
             {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -863,10 +863,10 @@ namespace esphome
             case 0x4004:
                 LOG_MESSAGE(ENUM_IN_OPERATION_VENT_MODE, message.value, source, dest);
                 break;
-            case == 0x4011:
+            case 0x4011:
                 LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
                 break;
-            case == 0x4012:
+            case 0x4012:
                 LOG_MESSAGE(ENUM_in_louver_hl_part_swing, message.value, source, dest);
                 break;
             case 0x4060:

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -853,7 +853,7 @@ namespace esphome
             if (source == "20.00.00" || source == "20.00.01" || source == "20.00.03")
                 return;
 
-            // return; //The use of return here was breaking the code here, I didn't understand why it was breaking it, so I made a temporary comment line.
+            return; // :)
 
             switch ((uint16_t)message.messageNumber)
             {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -791,7 +791,10 @@ namespace esphome
 
             target->register_address(source);
 
-            LOG_MESSAGE(MSG, packet_.to_string().c_str(), source, dest);
+            if (debug_log_undefined_messages)
+            {
+                ESP_LOGW(TAG, "MSG: %s", packet_.to_string().c_str());
+            }
 
             if (packet_.command.dataType == DataType::Ack)
             {
@@ -847,67 +850,66 @@ namespace esphome
 
         void process_messageset_debug(std::string source, std::string dest, MessageSet &message, MessageTarget *target)
         {
-            if (source == "20.00.00" ||
-                source == "20.00.01" ||
-                source == "20.00.03")
+            if (source == "20.00.00" || source == "20.00.01" || source == "20.00.03")
                 return;
+
             if (((uint16_t)message.messageNumber) == 0x4003)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_OPERATION_VENT_POWER %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_OPERATION_VENT_POWER, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x4004)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_OPERATION_VENT_MODE %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_OPERATION_VENT_MODE, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x4011)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_LOUVER_HL_SWING %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x4012)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_in_louver_hl_part_swing %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_in_louver_hl_part_swing, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x4060)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_ALTERNATIVE_MODE %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_ALTERNATIVE_MODE, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x406E)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_QUIET_MODE %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_QUIET_MODE, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x4119)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_OPERATION_POWER_ZONE1 %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_OPERATION_POWER_ZONE1, message.value, source, dest);
+                break;
             }
             if (((uint16_t)message.messageNumber) == 0x411E)
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_OPERATION_POWER_ZONE2 %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_OPERATION_POWER_ZONE2, message.value, source, dest);
+                break;
             }
 
-            return;
+            // return; //The use of return here was breaking the code here, I didn't understand why it was breaking it, so I made a temporary comment line.
 
             switch ((uint16_t)message.messageNumber)
             {
             case 0x4002: // ENUM_in_operation_mode_real
             {
                 // Todo Map
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_in_operation_mode_real %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_in_operation_mode_real, message.value, source, dest);
+                break;
             }
 
             case 0x4008: // ENUM_in_fan_vent_mode
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_in_fan_vent_mode %li", source.c_str(), dest.c_str(), message.value);
+                LOG_MESSAGE(ENUM_in_fan_vent_mode, message.value, source, dest);
                 // fan_vent_mode_to_fanmode();
-                return;
+                break;
             }
 
             case 0x4011: // ENUM_IN_LOUVER_HL_SWING
@@ -921,156 +923,156 @@ namespace esphome
     default:
     return undefined;
                 */
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_LOUVER_HL_SWING %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
+                break;
             }
 
             case 0x4012: // ENUM_IN_LOUVER_HL_SWING
             {
                 // Todo Map
 
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_IN_LOUVER_HL_SWING %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_IN_LOUVER_HL_SWING, message.value, source, dest);
+                break;
             }
 
             case 0x4205: // VAR_in_temp_eva_in_f unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_eva_in_f %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_in_temp_eva_in_f, temp, source, dest);
+                break;
             }
 
             case 0x4206: // VAR_in_temp_eva_out_f unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_in_temp_eva_out_f %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_in_temp_eva_out_f, temp, source, dest);
+                break;
             }
 
             case 0x4211: // VAR_in_capacity_request unit = 'kW'
             {
                 double temp = (double)message.value / (double)8.6;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_in_capacity_request %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_in_capacity_request, temp, source, dest);
+                break;
             }
 
             case 0x8001: // ENUM_out_operation_odu_mode
             {
                 // Todo Map
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_out_operation_odu_mode %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_out_operation_odu_mode, message.value, source, dest);
+                break;
             }
 
             case 0x8003: // ENUM_out_operation_heatcool
             {
                 //['Undefined', 'Cool', 'Heat', 'CoolMain', 'HeatMain'];
                 // Todo Map
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_out_operation_heatcool %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_out_operation_heatcool, message.value, source, dest);
+                break;
             }
 
             case 0x801a: // ENUM_out_load_4way
             {
-                ESP_LOGW(TAG, "s:%s d:%s ENUM_out_load_4way %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(ENUM_out_load_4way, message.value, source, dest);
+                break;
             }
 
             case 0x8235: // VAR_out_error_code
             {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(VAR_out_error_code, message.value, source, dest);
+                break;
             }
 
             case 0x8261: // VAR_OUT_SENSOR_PIPEIN3 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEIN3 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN3, temp, source, dest);
+                break;
             }
 
             case 0x8262: // VAR_OUT_SENSOR_PIPEIN4 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEIN4 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN4, temp, source, dest);
+                break;
             }
 
             case 0x8263: // VAR_OUT_SENSOR_PIPEIN5 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEIN5 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEIN5, temp, source, dest);
+                break;
             }
 
             case 0x8264: // VAR_OUT_SENSOR_PIPEOUT1 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEOUT1 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT1, temp, source, dest);
+                break;
             }
 
             case 0x8265: // VAR_OUT_SENSOR_PIPEOUT2 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEOUT2 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT2, temp, source, dest);
+                break;
             }
 
             case 0x8266: // VAR_OUT_SENSOR_PIPEOUT3 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEOUT3 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT3, temp, source, dest);
+                break;
             }
 
             case 0x8267: // VAR_OUT_SENSOR_PIPEOUT4 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEOUT4 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT4, temp, source, dest);
+                break;
             }
 
             case 0x8268: // VAR_OUT_SENSOR_PIPEOUT5 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_SENSOR_PIPEOUT5 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_OUT_SENSOR_PIPEOUT5, temp, source, dest);
+                break;
             }
 
             case 0x8274: // VAR_out_control_order_cfreq_comp2
             {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_out_control_order_cfreq_comp2 %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(VAR_out_control_order_cfreq_comp2, message.value, source, dest);
+                break;
             }
             case 0x8275: // VAR_out_control_target_cfreq_comp2
             {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_out_control_target_cfreq_comp2 %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(VAR_out_control_target_cfreq_comp2, message.value, source, dest);
+                break;
             }
 
             case 0x82bc: // VAR_OUT_PROJECT_CODE
             {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_PROJECT_CODE %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(VAR_OUT_PROJECT_CODE, message.value, source, dest);
+                break;
             }
 
             case 0x82e3: // VAR_OUT_PRODUCT_OPTION_CAPA
             {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_PRODUCT_OPTION_CAPA %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(VAR_OUT_PRODUCT_OPTION_CAPA, message.value, source, dest);
+                break;
             }
 
             case 0x8280: // VAR_out_sensor_top1 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;
-                ESP_LOGW(TAG, "s:%s d:%s VAR_out_sensor_top1 %f", source.c_str(), dest.c_str(), temp);
-                return;
+                LOG_MESSAGE(VAR_out_sensor_top1, temp, source, dest);
+                break;
             }
 
             case 0x82db: // VAR_OUT_PHASE_CURRENT
             {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_OUT_PHASE_CURRENT %li", source.c_str(), dest.c_str(), message.value);
-                return;
+                LOG_MESSAGE(VAR_OUT_PHASE_CURRENT, message.value, source, dest);
+                break;
             }
 
             case 0x402:
@@ -1212,7 +1214,7 @@ namespace esphome
             case 0x24fc:
             {
                 // ESP_LOGW(TAG, "s:%s d:%s Todo %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
-                return; // Todo
+                break; // Todo
             }
 
             case 0x8601: // STR_out_install_inverter_and_bootloader_info
@@ -1222,20 +1224,23 @@ namespace esphome
             case 0x600:  // STR_ad_option_basic
             case 0x202:  // VAR_ad_error_code1
             case 0x42d1: // VAR_IN_DUST_SENSOR_PM10_0_VALUE
-            {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM10_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
-                return; // Ingore cause not important
-            }
+                if (debug_log_messages)
+                {
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM10_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                }
+                break;   // Ingore cause not important
             case 0x42d2: // VAR_IN_DUST_SENSOR_PM2_5_VALUE
-            {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM2_5_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
-                return; // Ingore cause not important
-            }
+                if (debug_log_messages)
+                {
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM2_5_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                }
+                break;   // Ingore cause not important
             case 0x42d3: // VAR_IN_DUST_SENSOR_PM1_0_VALUE
-            {
-                ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM1_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
-                return; // Ingore cause not important
-            }
+                if (debug_log_messages)
+                {
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM1_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                }
+                break; // Ingore cause not important
 
             case 0x23:
             case 0x61d:
@@ -1282,13 +1287,16 @@ namespace esphome
             case 0x4006:
             {
                 // ESP_LOGW(TAG, "s:%s d:%s NoMap %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
-                return; // message types witch have no mapping in xml
+                break; // message types witch have no mapping in xml
             }
 
             default:
-                ESP_LOGW(TAG, "s:%s d:%s !! unknown %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+                if (debug_log_undefined_messages)
+                {
+                    ESP_LOGW(TAG, "s:%s d:%s !! unknown %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+                }
+                break;
             }
-            return;
         }
 
         void NasaProtocol::protocol_update(MessageTarget *target)

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -770,7 +770,7 @@ namespace esphome
                     value = (double)message.value / 10.0;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s VAR_IN_FSV_3022 %f", source.c_str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s VAR_IN_FSV_3022 %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -779,7 +779,7 @@ namespace esphome
                     value = (double)message.value / 10.0;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s VAR_IN_FSV_3023 %f", source.c_str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s VAR_IN_FSV_3023 %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -788,7 +788,7 @@ namespace esphome
                     value = (double)message.value / 1000.0;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s LVAR_OUT_CONTROL_WATTMETER_ALL_UNIT_ACCUM %fkwh", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s LVAR_OUT_CONTROL_WATTMETER_ALL_UNIT_ACCUM %fkwh", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -797,7 +797,7 @@ namespace esphome
                     value = (double)message.value;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s LVAR_OUT_CONTROL_WATTMETER_1W_1MIN_SUM %f", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s LVAR_OUT_CONTROL_WATTMETER_1W_1MIN_SUM %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -806,7 +806,7 @@ namespace esphome
                     value = (double)message.value;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s NASA_OUTDOOR_CONTROL_WATTMETER_1UNIT  %f", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s NASA_OUTDOOR_CONTROL_WATTMETER_1UNIT  %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -815,7 +815,7 @@ namespace esphome
                     value = (double)message.value;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s total produced energy  %f", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s total produced energy  %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -824,7 +824,7 @@ namespace esphome
                     value = (double)message.value;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s actual produced energy %f", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s actual produced energy %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -833,7 +833,7 @@ namespace esphome
                     value = (double)message.value;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s NASA_OUTDOOR_CONTROL_WATTMETER_TOTAL_SUM %f", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s NASA_OUTDOOR_CONTROL_WATTMETER_TOTAL_SUM %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
@@ -842,14 +842,14 @@ namespace esphome
                     value = (double)message.value;
                     if (debug_log_messages)
                     {
-                        ESP_LOGW(TAG, "s:%s d:%s NASA_OUTDOOR_CONTROL_WATTMETER_TOTAL_SUM_ACCUM %f", source.c.str(), dest.c.str(), value);
+                        ESP_LOGW(TAG, "s:%s d:%s NASA_OUTDOOR_CONTROL_WATTMETER_TOTAL_SUM_ACCUM %f", source.c_str(), dest.c_str(), value);
                     }
                     break;
 
                 default:
                     if (debug_log_undefined_messages)
                     {
-                        ESP_LOGW(TAG, "Undefined s:%s d:%s %s", source.c.str(), dest.c.str(), message.to_string().c.str());
+                        ESP_LOGW(TAG, "Undefined s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
                     }
                     break;
                 }

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -549,7 +549,7 @@ namespace esphome
                 std::string topic_suffix;
                 std::string payload;
 
-                if (message.messageNumber != 0)
+                if (static_cast<int>(message.messageNumber) != 0)
                 {
                     topic_suffix = long_to_hex((uint16_t)message.messageNumber);
                     payload = std::to_string(message.value);
@@ -791,7 +791,7 @@ namespace esphome
 
             target->register_address(source);
 
-            LOG_MESSAGE(MSG, packet_.to_string().c_str(), "", "");
+            LOG_MESSAGE(MSG, packet_.to_string().c_str(), source.c_str(), dest.c_str());
 
             if (packet_.command.dataType == DataType::Ack)
             {

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -71,6 +71,7 @@ namespace esphome
         {
             Undefiend = 0,
             ENUM_in_operation_power = 0x4000,
+            ENUM_in_operation_automatic_cleaning = 0x4111,
             ENUM_in_water_heater_power = 0x4065,
             ENUM_in_operation_mode = 0x4001,
             ENUM_in_water_heater_mode = 0x4066,
@@ -86,6 +87,8 @@ namespace esphome
             VAR_in_temp_water_tank_f = 0x4237,
             VAR_out_sensor_airout = 0x8204,
             VAR_in_temp_water_heater_target_f = 0x4235,
+            VAR_IN_TEMP_EVA_IN_F = 0x4205,
+            VAR_IN_TEMP_EVA_OUT_F = 0x4206,
         };
 
         struct Address

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -87,8 +87,8 @@ namespace esphome
             VAR_in_temp_water_tank_f = 0x4237,
             VAR_out_sensor_airout = 0x8204,
             VAR_in_temp_water_heater_target_f = 0x4235,
-            VAR_IN_TEMP_EVA_IN_F = 0x4205,
-            VAR_IN_TEMP_EVA_OUT_F = 0x4206,
+            VAR_in_temp_eva_in_f = 0x4205,
+            VAR_in_temp_eva_out_f = 0x4206,
         };
 
         struct Address

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -538,7 +538,7 @@ namespace esphome
 
         void process_non_nasa_packet(MessageTarget *target)
         {
-            if (debug_log_messages)
+            if (debug_log_undefined_messages)
             {
                 ESP_LOGW(TAG, "MSG: %s", nonpacket_.to_string().c_str());
             }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -538,7 +538,7 @@ namespace esphome
 
         void process_non_nasa_packet(MessageTarget *target)
         {
-            if (debug_log_packets)
+            if (debug_log_messages)
             {
                 ESP_LOGW(TAG, "MSG: %s", nonpacket_.to_string().c_str());
             }
@@ -564,7 +564,7 @@ namespace esphome
                                                     item.request.fanspeed == nonpacket_.command20.fanspeed &&
                                                     item.request.mode == nonpacket_.command20.mode &&
                                                     item.request.power == nonpacket_.command20.power; });
-                                                    
+
                 // If a state update comes through after a control message has been sent, but before it
                 // has been acknowledged, it should be ignored. This prevents the UI status bouncing
                 // between states after a command has been issued.
@@ -591,7 +591,7 @@ namespace esphome
                    // TODO
                    target->set_water_heater_power(nonpacket_.src, false);
                    target->set_mode(nonpacket_.src, nonnasa_mode_to_mode(nonpacket_.command20.mode));
-				   // TODO
+                   // TODO
 				   target->set_water_heater_mode(nonpacket_.src, nonnasa_water_heater_mode_to_mode(-0));
                    target->set_fanmode(nonpacket_.src, nonnasa_fanspeed_to_fanmode(nonpacket_.command20.fanspeed));
                    // TODO

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -10,12 +10,18 @@ namespace esphome
   {
     void Samsung_AC::setup()
     {
-      ESP_LOGW(TAG, "setup");
+      if (debug_log_messages)
+      {
+        ESP_LOGW(TAG, "setup");
+      }
     }
 
     void Samsung_AC::update()
     {
-      ESP_LOGW(TAG, "update");
+      if (debug_log_messages)
+      {
+        ESP_LOGW(TAG, "update");
+      }
 
       debug_mqtt_connect(debug_mqtt_host, debug_mqtt_port, debug_mqtt_username, debug_mqtt_password);
 

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -39,7 +39,7 @@ namespace esphome
 
       void set_debug_log_messages(bool value)
       {
-        debug_log_packets = value;
+        debug_log_messages = value;
       }
 
       void set_debug_log_messages_raw(bool value)
@@ -51,7 +51,10 @@ namespace esphome
       {
         non_nasa_keepalive = value;
       }
-
+      void set_debug_log_undefined_messages(bool value)
+      {
+        debug_log_undefined_messages = value;
+      }
       void register_device(Samsung_AC_Device *device);
 
       void /*MessageTarget::*/ register_address(const std::string address) override
@@ -80,13 +83,27 @@ namespace esphome
           dev->update_outdoor_temperature(value);
       }
 
+      void /*MessageTarget::*/ set_indoor_eva_in_temperature(const std::string address, float value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_indoor_eva_in_temperature(value);
+      }
+
+      void /*MessageTarget::*/ set_indoor_eva_out_temperature(const std::string address, float value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_indoor_eva_out_temperature(value);
+      }
+
       void /*MessageTarget::*/ set_target_temperature(const std::string address, float value) override
       {
         Samsung_AC_Device *dev = find_device(address);
         if (dev != nullptr)
           dev->update_target_temperature(value);
       }
-      
+
       void /*MessageTarget::*/ set_water_outlet_target(const std::string address, float value) override
       {
         Samsung_AC_Device *dev = find_device(address);
@@ -106,6 +123,12 @@ namespace esphome
         Samsung_AC_Device *dev = find_device(address);
         if (dev != nullptr)
           dev->update_power(value);
+      }
+      void /*MessageTarget::*/ set_automatic_cleaning(const std::string address, bool value) override
+      {
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_automatic_cleaning(value);
       }
       void /*MessageTarget::*/ set_water_heater_power(const std::string address, bool value) override
       {

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -105,10 +105,13 @@ namespace esphome
       std::string address;
       sensor::Sensor *room_temperature{nullptr};
       sensor::Sensor *outdoor_temperature{nullptr};
+      sensor::Sensor *indoor_eva_in_temperature{nullptr};
+      sensor::Sensor *indoor_eva_out_temperature{nullptr};
       Samsung_AC_Number *target_temperature{nullptr};
       Samsung_AC_Number *water_outlet_target{nullptr};
       Samsung_AC_Number *target_water_temperature{nullptr};
       Samsung_AC_Switch *power{nullptr};
+      Samsung_AC_Switch *automatic_cleaning{nullptr};
       Samsung_AC_Switch *water_heater_power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Water_Heater_Mode_Select *waterheatermode{nullptr};
@@ -124,6 +127,16 @@ namespace esphome
       void set_outdoor_temperature_sensor(sensor::Sensor *sensor)
       {
         outdoor_temperature = sensor;
+      }
+
+      void set_indoor_eva_in_temperature_sensor(sensor::Sensor *sensor)
+      {
+        indoor_eva_in_temperature = sensor;
+      }
+
+      void set_indoor_eva_out_temperature_sensor(sensor::Sensor *sensor)
+      {
+        indoor_eva_out_temperature = sensor;
       }
 
       void add_custom_sensor(int message_number, sensor::Sensor *sensor)
@@ -149,6 +162,17 @@ namespace esphome
         {
           ProtocolRequest request;
           request.power = value;
+          publish_request(request);
+        };
+      }
+
+      void set_automatic_cleaning_switch(Samsung_AC_Switch *switch_)
+      {
+        automatic_cleaning = switch_;
+        automatic_cleaning->write_state_ = [this](bool value)
+        {
+          ProtocolRequest request;
+          request.automatic_cleaning = value;
           publish_request(request);
         };
       }
@@ -196,7 +220,7 @@ namespace esphome
           publish_request(request);
         };
       };
-      
+
       void set_water_outlet_target_number(Samsung_AC_Number *number)
       {
         water_outlet_target = number;
@@ -235,7 +259,7 @@ namespace esphome
           climate->publish_state();
         }
       }
-      
+
       void update_water_outlet_target(float value)
       {
         if (water_outlet_target != nullptr)
@@ -249,6 +273,7 @@ namespace esphome
       }
 
       optional<bool> _cur_power;
+      optional<bool> _cur_automatic_cleaning;
       optional<bool> _cur_water_heater_power;
       optional<Mode> _cur_mode;
       optional<WaterHeaterMode> _cur_water_heater_mode;
@@ -258,6 +283,15 @@ namespace esphome
         _cur_power = value;
         if (power != nullptr)
           power->publish_state(value);
+        if (climate != nullptr)
+          calc_and_publish_mode();
+      }
+
+      void update_automatic_cleaning(bool value)
+      {
+        _cur_automatic_cleaning = value;
+        if (automatic_cleaning != nullptr)
+          automatic_cleaning->publish_state(value);
         if (climate != nullptr)
           calc_and_publish_mode();
       }
@@ -367,6 +401,18 @@ namespace esphome
       {
         if (outdoor_temperature != nullptr)
           outdoor_temperature->publish_state(value);
+      }
+
+      void update_indoor_eva_in_temperature(float value)
+      {
+        if (indoor_eva_in_temperature != nullptr)
+          indoor_eva_in_temperature->publish_state(value);
+      }
+
+      void update_indoor_eva_out_temperature(float value)
+      {
+        if (indoor_eva_out_temperature != nullptr)
+          indoor_eva_out_temperature->publish_state(value);
       }
 
       void update_custom_sensor(uint16_t message_number, float value)

--- a/example.yaml
+++ b/example.yaml
@@ -56,6 +56,12 @@ samsung_ac:
   # For NonNASA devices the following option can be enabled to prevent the device from sleeping when idle. This allows
   # values like internal and external temperature to continue to be tracked when the device isn't in use.
   non_nasa_keepalive: true
+  
+  #When enabled (set to true), this option will log the messages associated with undefined codes on the device. This is useful for debugging and identifying any unexpected or unknown codes that the device may receive during operation.
+  debug_log_undefined_messages: false
+  
+  #When enabled (set to true), this option logs messages associated with defined codes on the device. This helps in monitoring the behavior of the device by recording the activity related to known, expected codes.
+  debug_log_messages: false
 
   # Capabilities configure the features alle devices of your AC system have (all parts of this section are optional). 
   # All capabilities are off by default, you need to enable only those your devices have.
@@ -104,6 +110,12 @@ samsung_ac:
         name: "Kitchen power"
       mode:
         name: "Kitchen mode"
+
+      #Add automatic_cleaning mode for Samsung AC NASA
+            #- Added the "automatic_cleaning" feature to the Samsung AC integration.
+            #- This mode ensures hygienic drying of all moisture in the indoor unit after the cooling process is completed.
+      automatic_cleaning:
+        name: "Kitchen automatic clean"
 
       # If your AC sits near or inside the ceiling, the reported room temperature is often a little bit heigher then whats 
       # measured below. This property can be used to correct that value.


### PR DESCRIPTION
This pull request introduces the automatic cleaning mode to the Samsung AC integration, enhancing the functionality and ensuring a more hygienic environment.

- Resolves #121

**Key Features:**

**- Automatic Cleaning Mode:**
 - Ensures hygienic drying of all moisture in the indoor unit after the cooling process is completed, providing an added layer of cleanliness and efficiency.

**- Logging Enhancements:**
 - **debug_log_messages:** This option allows for logging of all defined messages. When enabled (true), all standard log messages will be recorded, providing a clear overview of system operations.
 - **debug_log_undefined_messages:** This option logs any undefined messages, helping in debugging and identifying any unexpected or unhandled operations.
 - If both debug_log_messages and debug_log_undefined_messages are set to false, only the logs for the operations executed via SmartThings will be visible. This approach minimizes unnecessary log clutter while still providing essential logging for new features and functions.

**Changes Made Based on Previous Feedback:**
- Resolved all conflicts.
- Fixed indentation issues for better code readability.
- Renamed log parameters to start with debug_ for consistency with existing log options.
- Implemented the debug_log_messages functionality that was previously missing.
- Corrected the repository source address in the example YAML file.

This PR addresses and resolves the issues raised in the previous pull request and is now ready for review.
