### PR TITLE
Fix build on ESP-IDF: Change logging message type interpolation

### DIFF
--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -24,7 +24,7 @@ namespace esphome
 #define LOG_MESSAGE(message_name, temp, source, dest)                                        \
     if (debug_log_messages)                                                                  \
     {                                                                                        \
-        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %f", source.c_str(), dest.c_str(), temp); \
+        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), static_cast<double>(temp)); \
     }
 
         uint16_t crc16(std::vector<uint8_t> &data, int startIndex, int length)


### PR DESCRIPTION
This solves https://github.com/lanwin/esphome_samsung_ac/issues/165. 

I had an issue with this config (slightly simplified to keep it short):

<details>

```
substitutions:
  name: ac-control-beta
  friendly_name: AC Control Beta (Eastern ACs)

esphome:
  name: ${name}
  friendly_name: ${friendly_name}
  min_version: 2024.6.0
  name_add_mac_suffix: false
  compile_process_limit: 1
  project:
    name: esphome.web
    version: "1.0"

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: INFO
  baud_rate: 0
  logs:
    component: ERROR # Remove the "Your component takes to long to respond warning"

api:

ota:
  platform: esphome

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

captive_portal:

uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  parity: EVEN
  baud_rate: 9600


## SAMSUNG AC CONFIGURATION
external_components:
  - source: github://lanwin/esphome_samsung_ac@0e3463e
     components: [samsung_ac]
  #- source:
   #   type: local
   #   path: "/data/external_components/experiment/components"
   # components: [samsung_ac]

# Configuration of AC component
samsung_ac:
  capabilities:
    vertical_swing: true
    horizontal_swing: true
    presets:
      quiet: true
      fast: true
      windfree: true
      sleep: true
 
  non_nasa_keepalive: false

  devices:
    - address: "20.00.00"
      climate:
        name: "Haven room AC"
      room_temperature:
        name: "Haven room AC temperature"
      target_temperature:
        name: "Haven room AC target temperature"
      power:
        name: "Haven room AC power"
      mode:
        name: "Haven room AC mode"
      room_humidity:
        name: "Haven room AC humidity"
      room_temperature_offset: -1
      automatic_cleaning:
        name: "Haven room AC automatic clean"

bluetooth_proxy:
  active: true

esp32_ble_tracker:
  scan_parameters:
    interval: 1100ms
    window: 1100ms
    active: true

```

</details>

and after this change, I was able to compile a new firmware just fine.