### PR TITLE
Error code monitoring

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -365,7 +365,12 @@ async def to_code(config):
             conf = device[CONF_DEVICE_INDOOR_EVA_OUT_TEMPERATURE]
             sens = await sensor.new_sensor(conf)
             cg.add(var_dev.set_indoor_eva_out_temperature_sensor(sens))
-
+            
+        if CONF_DEVICE_ERROR_CODE in device:
+            conf = device[CONF_DEVICE_ERROR_CODE]
+            sens = await sensor.new_sensor(conf)
+            cg.add(var_dev.set_error_code_sensor(sens))
+            
         if CONF_DEVICE_WATER_TARGET_TEMPERATURE in device:
             conf = device[CONF_DEVICE_WATER_TARGET_TEMPERATURE]
             conf[CONF_UNIT_OF_MEASUREMENT] = UNIT_CELSIUS
@@ -413,11 +418,6 @@ async def to_code(config):
             var_cli = cg.new_Pvariable(conf[CONF_ID])
             await climate.register_climate(var_cli, conf)
             cg.add(var_dev.set_climate(var_cli))
-            
-        if CONF_DEVICE_ERROR_CODE in device:
-            conf = device[CONF_DEVICE_ERROR_CODE]
-            sens = await sensor.new_sensor(conf)
-            cg.add(var_dev.set_error_code_sensor(sens))
 
         if CONF_DEVICE_CUSTOM in device:
             for cust_sens in device[CONF_DEVICE_CUSTOM]:

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -16,7 +16,6 @@ from esphome.core import (
     CORE,
     Lambda
 )
-from .error_codes import ERROR_CODES
 
 CODEOWNERS = ["matthias882", "lanwin"]
 DEPENDENCIES = ["uart"]
@@ -208,6 +207,7 @@ DEVICE_SCHEMA = (
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_DEVICE_ERROR_CODE): error_code_sensor_schema(0x8235),
             cv.Optional(CONF_DEVICE_TARGET_TEMPERATURE): NUMBER_SCHEMA,
             cv.Optional(CONF_DEVICE_WATER_OUTLET_TARGET): NUMBER_SCHEMA,
             cv.Optional(CONF_DEVICE_WATER_TARGET_TEMPERATURE): NUMBER_SCHEMA,
@@ -222,7 +222,6 @@ DEVICE_SCHEMA = (
             # keep CUSTOM_SENSOR_KEYS in sync with these
             cv.Optional(CONF_DEVICE_WATER_TEMPERATURE): temperature_sensor_schema(0x4237),
             cv.Optional(CONF_DEVICE_ROOM_HUMIDITY): humidity_sensor_schema(0x4038),
-            cv.Optional(CONF_DEVICE_ERROR_CODE): error_code_sensor_schema(0x8235),
         }
     )
 )
@@ -230,7 +229,6 @@ DEVICE_SCHEMA = (
 CUSTOM_SENSOR_KEYS = [
     CONF_DEVICE_WATER_TEMPERATURE,
     CONF_DEVICE_ROOM_HUMIDITY,
-    CONF_DEVICE_ERROR_CODE,
 ]
 
 CONF_DEVICES = "devices"

--- a/components/samsung_ac/error_codes.py
+++ b/components/samsung_ac/error_codes.py
@@ -1,0 +1,4 @@
+ERROR_CODES = {
+    201: "Communication error between indoor and outdoor units (installation number setting error,repeated indoor unit address, indoor unit communication cable error)",
+    # ...
+}

--- a/components/samsung_ac/error_codes.py
+++ b/components/samsung_ac/error_codes.py
@@ -1,4 +1,0 @@
-ERROR_CODES = {
-    201: "Communication error between indoor and outdoor units (installation number setting error,repeated indoor unit address, indoor unit communication cable error)",
-    # ...
-}

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -94,7 +94,7 @@ namespace esphome
             virtual void set_swing_horizontal(const std::string address, bool horizontal) = 0;
             virtual optional<std::set<uint16_t>> get_custom_sensors(const std::string address) = 0;
             virtual void set_custom_sensor(const std::string address, uint16_t message_number, float value) = 0;
-            virtual void publish_error_code(const std::string &source, int error_code) = 0;
+            virtual void publish_error_code(const std::string &source, int error_code);
         };
 
         struct ProtocolRequest

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -94,7 +94,7 @@ namespace esphome
             virtual void set_swing_horizontal(const std::string address, bool horizontal) = 0;
             virtual optional<std::set<uint16_t>> get_custom_sensors(const std::string address) = 0;
             virtual void set_custom_sensor(const std::string address, uint16_t message_number, float value) = 0;
-            virtual void publish_error_code(const std::string &source, int error_code) = 0;
+            virtual void set_error_code(const std::string address, int error_code) = 0;
         };
 
         struct ProtocolRequest

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -32,7 +32,7 @@ namespace esphome
             Fan = 3,
             Heat = 4,
         };
-        
+
         enum class WaterHeaterMode
         {
             Unknown = -1,
@@ -94,7 +94,7 @@ namespace esphome
             virtual void set_swing_horizontal(const std::string address, bool horizontal) = 0;
             virtual optional<std::set<uint16_t>> get_custom_sensors(const std::string address) = 0;
             virtual void set_custom_sensor(const std::string address, uint16_t message_number, float value) = 0;
-            virtual void publish_error_code(const std::string &source, int error_code);
+            virtual void publish_error_code(const std::string &source, int error_code) = 0;
         };
 
         struct ProtocolRequest

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -94,6 +94,7 @@ namespace esphome
             virtual void set_swing_horizontal(const std::string address, bool horizontal) = 0;
             virtual optional<std::set<uint16_t>> get_custom_sensors(const std::string address) = 0;
             virtual void set_custom_sensor(const std::string address, uint16_t message_number, float value) = 0;
+            virtual void publish_error_code(const std::string &source, int error_code) = 0;
         };
 
         struct ProtocolRequest

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1239,7 +1239,7 @@ namespace esphome
         }
         void NasaProtocol::publish_error_code(const std::string &source, int error_code)
         {
-            ESP_LOGW("NasaProtocol", "Error Code from %s: %d", source.c_str(), error_code);
+            ESP_LOGW("ERROR", "Error code from %s: %d", source.c_str(), error_code);
         }
         void NasaProtocol::protocol_update(MessageTarget *target)
         {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -21,9 +21,9 @@ namespace esphome
             return value - (int)65535 /*uint16 max*/ - 1.0;
         }
 
-#define LOG_MESSAGE(message_name, temp, source, dest)                                                             \
-    if (debug_log_messages)                                                                                       \
-    {                                                                                                             \
+#define LOG_MESSAGE(message_name, temp, source, dest)                                        \
+    if (debug_log_messages)                                                                  \
+    {                                                                                        \
         ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), static_cast<double>(temp)); \
     }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -24,7 +24,7 @@ namespace esphome
 #define LOG_MESSAGE(message_name, temp, source, dest)                                        \
     if (debug_log_messages)                                                                  \
     {                                                                                        \
-        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), temp); \
+        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), static_cast<double>(temp)); \
     }
 
         uint16_t crc16(std::vector<uint8_t> &data, int startIndex, int length)

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1233,6 +1233,11 @@ namespace esphome
             }
         }
 
+        void NasaProtocol::publish_error_code(const std::string &source, int error_code)
+        {
+            ESP_LOGW(TAG, "Error code from %s: %d", source.c_str(), error_code);
+        }
+
         void NasaProtocol::protocol_update(MessageTarget *target)
         {
             // Unused for NASA protocol

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -714,8 +714,8 @@ namespace esphome
             }
             case MessageNumber::VAR_out_error_code:
             {
-                LOG_MESSAGE(VAR_out_error_code, (double)message.value, source, dest);
-                target->publish_error_code(source, message.value);
+                LOG_MESSAGE(VAR_out_error_code, (int)message.value, source, dest);
+                target->set_error_code(source, message.value);
                 break;
             }
 
@@ -1233,14 +1233,6 @@ namespace esphome
             }
         }
 
-        void MessageTarget::publish_error_code(const std::string &source, int error_code)
-        {
-            ESP_LOGW("ERROR", "Error code from %s: %d", source.c_str(), error_code);
-        }
-        void NasaProtocol::publish_error_code(const std::string &source, int error_code)
-        {
-            ESP_LOGW("ERROR", "Error code from %s: %d", source.c_str(), error_code);
-        }
         void NasaProtocol::protocol_update(MessageTarget *target)
         {
             // Unused for NASA protocol

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -715,7 +715,7 @@ namespace esphome
             case MessageNumber::VAR_out_error_code:
             {
                 LOG_MESSAGE(VAR_out_error_code, (int)message.value, source, dest);
-                target->set_error_code(source, message.value);
+                target->set_error_code(source, (int)message.value);
                 break;
             }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -714,7 +714,7 @@ namespace esphome
             }
             case MessageNumber::VAR_out_error_code:
             {
-                int code = ((int16_t)message.value);
+                int code = ((int32_t)message.value);
                 LOG_MESSAGE(VAR_out_error_code, code, source, dest);
                 target->set_error_code(source, code);
                 break;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -714,9 +714,9 @@ namespace esphome
             }
             case MessageNumber::VAR_out_error_code:
             {
-                int code = ((int32_t)message.value);
+                int code = static_cast<int>(message.value);
                 LOG_MESSAGE(VAR_out_error_code, code, source, dest);
-                target->set_error_code(source, code);
+                //target->set_error_code(source, code);
                 break;
             }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -714,8 +714,9 @@ namespace esphome
             }
             case MessageNumber::VAR_out_error_code:
             {
-                LOG_MESSAGE(VAR_out_error_code, (int)message.value, source, dest);
-                target->set_error_code(source, (int)message.value);
+                int code = ((int16_t)message.value);
+                LOG_MESSAGE(VAR_out_error_code, code, source, dest);
+                target->set_error_code(source, code);
                 break;
             }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -24,7 +24,7 @@ namespace esphome
 #define LOG_MESSAGE(message_name, temp, source, dest)                                        \
     if (debug_log_messages)                                                                  \
     {                                                                                        \
-        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %f", source.c_str(), dest.c_str(), temp); \
+        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), temp); \
     }
 
         uint16_t crc16(std::vector<uint8_t> &data, int startIndex, int length)

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -21,9 +21,9 @@ namespace esphome
             return value - (int)65535 /*uint16 max*/ - 1.0;
         }
 
-#define LOG_MESSAGE(message_name, temp, source, dest)                                        \
-    if (debug_log_messages)                                                                  \
-    {                                                                                        \
+#define LOG_MESSAGE(message_name, temp, source, dest)                                                             \
+    if (debug_log_messages)                                                                                       \
+    {                                                                                                             \
         ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), static_cast<double>(temp)); \
     }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -929,14 +929,6 @@ namespace esphome
                 LOG_MESSAGE(ENUM_out_load_4way, message.value, source, dest);
                 break;
 
-            case 0x8235: // VAR_out_error_code
-            {
-                int error_code = message.value;
-                LOG_MESSAGE(VAR_out_error_code, error_code, source, dest);
-                target->publish_error_code(source, error_code);
-                break;
-            }
-
             case 0x8261: // VAR_OUT_SENSOR_PIPEIN3 unit = 'Celsius'
             {
                 double temp = (double)message.value / (double)10;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -715,8 +715,11 @@ namespace esphome
             case MessageNumber::VAR_out_error_code:
             {
                 int code = static_cast<int>(message.value);
-                LOG_MESSAGE(VAR_out_error_code, code, source, dest);
-                //target->set_error_code(source, code);
+                if (debug_log_messages)
+                {
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %f", source.c_str(), dest.c_str(), code);
+                }
+                target->set_error_code(source, code);
                 break;
             }
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1237,7 +1237,10 @@ namespace esphome
         {
             ESP_LOGW("ERROR", "Error code from %s: %d", source.c_str(), error_code);
         }
-
+        void NasaProtocol::publish_error_code(const std::string &source, int error_code)
+        {
+            ESP_LOGW("NasaProtocol", "Error Code from %s: %d", source.c_str(), error_code);
+        }
         void NasaProtocol::protocol_update(MessageTarget *target)
         {
             // Unused for NASA protocol

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1233,9 +1233,9 @@ namespace esphome
             }
         }
 
-        void NasaProtocol::publish_error_code(const std::string &source, int error_code)
+        void MessageTarget::publish_error_code(const std::string &source, int error_code)
         {
-            ESP_LOGW(TAG, "Error code from %s: %d", source.c_str(), error_code);
+            ESP_LOGW("ERROR", "Error code from %s: %d", source.c_str(), error_code);
         }
 
         void NasaProtocol::protocol_update(MessageTarget *target)

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -717,7 +717,7 @@ namespace esphome
                 int code = static_cast<int>(message.value);
                 if (debug_log_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %f", source.c_str(), dest.c_str(), code);
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %f", source.c_str(), dest.c_str(), message.to_string().c_str());
                 }
                 target->set_error_code(source, code);
                 break;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -717,7 +717,7 @@ namespace esphome
                 int code = static_cast<int>(message.value);
                 if (debug_log_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %d", source.c_str(), dest.c_str(), message.to_string().c_str());
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %d", source.c_str(), dest.c_str(), code);
                 }
                 target->set_error_code(source, code);
                 break;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -712,6 +712,13 @@ namespace esphome
                 target->set_indoor_eva_out_temperature(source, temp);
                 break;
             }
+            case MessageNumber::VAR_out_error_code:
+            {
+                LOG_MESSAGE(VAR_out_error_code, (double)message.value, source, dest);
+                target->publish_error_code(source, message.value);
+                break;
+            }
+
             default:
             {
                 double value = 0;
@@ -923,8 +930,12 @@ namespace esphome
                 break;
 
             case 0x8235: // VAR_out_error_code
-                LOG_MESSAGE(VAR_out_error_code, message.value, source, dest);
+            {
+                int error_code = message.value;
+                LOG_MESSAGE(VAR_out_error_code, error_code, source, dest);
+                target->publish_error_code(source, error_code);
                 break;
+            }
 
             case 0x8261: // VAR_OUT_SENSOR_PIPEIN3 unit = 'Celsius'
             {

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -717,7 +717,7 @@ namespace esphome
                 int code = static_cast<int>(message.value);
                 if (debug_log_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %f", source.c_str(), dest.c_str(), message.to_string().c_str());
+                    ESP_LOGW(TAG, "s:%s d:%s VAR_out_error_code %d", source.c_str(), dest.c_str(), message.to_string().c_str());
                 }
                 target->set_error_code(source, code);
                 break;

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -179,7 +179,7 @@ namespace esphome
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
             void protocol_update(MessageTarget *target) override;
-            virtual void publish_error_code(const std::string &source, int error_code);
+            virtual void publish_error_code(const std::string &source, int error_code) override;
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -89,6 +89,7 @@ namespace esphome
             VAR_in_temp_water_heater_target_f = 0x4235,
             VAR_in_temp_eva_in_f = 0x4205,
             VAR_in_temp_eva_out_f = 0x4206,
+            VAR_out_error_code = 0x8235,
         };
 
         struct Address
@@ -177,6 +178,7 @@ namespace esphome
             NasaProtocol() = default;
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
+            virtual void publish_error_code(const std::string &source, int error_code) = 0;
             void protocol_update(MessageTarget *target) override;
         };
 

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -178,8 +178,8 @@ namespace esphome
             NasaProtocol() = default;
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
-            virtual void publish_error_code(const std::string &source, int error_code) = 0;
             void protocol_update(MessageTarget *target) override;
+            virtual void publish_error_code(const std::string &source, int error_code) override;
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -179,7 +179,7 @@ namespace esphome
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
             void protocol_update(MessageTarget *target) override;
-            virtual void publish_error_code(const std::string &source, int error_code) override;
+            virtual void publish_error_code(const std::string &source, int error_code);
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -178,7 +178,7 @@ namespace esphome
             NasaProtocol() = default;
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
-            virtual void publish_error_code(const std::string &source, int error_code) = 0;
+            void publish_error_code(const std::string &source, int error_code) = 0;
             void protocol_update(MessageTarget *target) override;
         };
 

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -178,7 +178,7 @@ namespace esphome
             NasaProtocol() = default;
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
-            void publish_error_code(const std::string &source, int error_code) = 0;
+            virtual void publish_error_code(const std::string &source, int error_code) = 0;
             void protocol_update(MessageTarget *target) override;
         };
 

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -179,7 +179,6 @@ namespace esphome
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
             void protocol_update(MessageTarget *target) override;
-            void publish_error_code(const std::string &source, int error_code);
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -179,7 +179,7 @@ namespace esphome
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
             void protocol_update(MessageTarget *target) override;
-            virtual void publish_error_code(const std::string &source, int error_code) override;
+            void publish_error_code(const std::string &source, int error_code);
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -194,7 +194,7 @@ namespace esphome
           dev->update_custom_sensor(message_number, value);
       }
 
-      void publish_error_code(const std::string &source, int error_code) override
+      void publish_error_code(const std::string &source, int error_code)
       {
         ESP_LOGW("Samsung_AC", "Error code from %s: %d", source.c_str(), error_code);
       }

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -193,10 +193,11 @@ namespace esphome
         if (dev != nullptr)
           dev->update_custom_sensor(message_number, value);
       }
-
-      void publish_error_code(const std::string &source, int error_code)
+      void /*MessageTarget::*/ set_error_code(const std::string address, int value) override
       {
-        ESP_LOGW("Samsung_AC", "Error code from %s: %d", source.c_str(), error_code);
+        Samsung_AC_Device *dev = find_device(address);
+        if (dev != nullptr)
+          dev->update_error_code(value);
       }
 
     protected:

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -143,7 +143,7 @@ namespace esphome
         if (dev != nullptr)
           dev->update_mode(mode);
       }
-      
+
       void /*MessageTarget::*/ set_water_heater_mode(const std::string address, WaterHeaterMode waterheatermode) override
       {
         Samsung_AC_Device *dev = find_device(address);
@@ -192,6 +192,11 @@ namespace esphome
         Samsung_AC_Device *dev = find_device(address);
         if (dev != nullptr)
           dev->update_custom_sensor(message_number, value);
+      }
+
+      void publish_error_code(const std::string &source, int error_code) override
+      {
+        ESP_LOGW("Samsung_AC", "Error code from %s: %d", source.c_str(), error_code);
       }
 
     protected:

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -56,7 +56,7 @@ namespace esphome
 
       std::function<void(Mode)> write_state_;
     };
-    
+
     class Samsung_AC_Water_Heater_Mode_Select : public select::Select
     {
     public:
@@ -107,6 +107,7 @@ namespace esphome
       sensor::Sensor *outdoor_temperature{nullptr};
       sensor::Sensor *indoor_eva_in_temperature{nullptr};
       sensor::Sensor *indoor_eva_out_temperature{nullptr};
+      sensor::Sensor *error_code{nullptr};
       Samsung_AC_Number *target_temperature{nullptr};
       Samsung_AC_Number *water_outlet_target{nullptr};
       Samsung_AC_Number *target_water_temperature{nullptr};
@@ -137,6 +138,11 @@ namespace esphome
       void set_indoor_eva_out_temperature_sensor(sensor::Sensor *sensor)
       {
         indoor_eva_out_temperature = sensor;
+      }
+
+      void set_error_code_sensor(sensor::Sensor *sensor)
+      {
+        error_code = sensor;
       }
 
       void add_custom_sensor(int message_number, sensor::Sensor *sensor)
@@ -198,7 +204,7 @@ namespace esphome
           publish_request(request);
         };
       }
-      
+
       void set_water_heater_mode_select(Samsung_AC_Water_Heater_Mode_Select *select)
       {
         waterheatermode = select;
@@ -311,7 +317,7 @@ namespace esphome
         if (climate != nullptr)
           calc_and_publish_mode();
       }
-      
+
       void update_water_heater_mode(WaterHeaterMode value)
       {
         _cur_water_heater_mode = value;
@@ -413,6 +419,12 @@ namespace esphome
       {
         if (indoor_eva_out_temperature != nullptr)
           indoor_eva_out_temperature->publish_state(value);
+      }
+
+      void update_error_code(int value)
+      {
+        if (error_code != nullptr)
+          error_code->publish_state(value);
       }
 
       void update_custom_sensor(uint16_t message_number, float value)

--- a/example.yaml
+++ b/example.yaml
@@ -124,6 +124,13 @@ samsung_ac:
       # Only supported on NASA devices
       room_humidity:
         name: "Kitchen humidity"
+      
+      # This sensor captures and monitors specific error codes returned by the HVAC system.
+      # When an error occurs, the sensor detects the error code and updates its value accordingly.
+      # Additionally, by using the blueprint available at https://github.com/omerfaruk-aran/esphome_samsung_ac_blueprint,
+      # you can automatically send detailed error messages to your mobile devices based on the captured error codes.
+      error_code:
+        name: "Error Code"
 
       # Only supported on NASA based heatpumps
       water_temperature:


### PR DESCRIPTION
This PR contains important updates for the `samsung_ac` component. The `error_code` sensor captures and monitors error codes returned by the HVAC system. The following changes and enhancements have been included:

**New Error Code Sensor:** The `error_code` sensor now captures error codes returned by the HVAC system and automatically updates its value. This sensor helps monitor error conditions and makes it easier for users to identify issues in the system.

**Blueprint Integration:** Thanks to the blueprint we've prepared, error codes can be sent to mobile devices, notifying users immediately of any errors in the system. For more information on this blueprint and how to use it, you can visit [this link](https://github.com/omerfaruk-aran/esphome_samsung_ac_blueprint).

**Documentation Update:** Updates to the `example.yaml` file provide better explanations, helping users understand the functionality of the new sensor.

**Blueprint Information:**
With the newly created blueprint repository, error messages corresponding to error codes captured by the `error_code` sensor can be sent to mobile devices. This feature is particularly useful for users who want to monitor HVAC systems remotely and respond immediately.

- **Issues Resolved:** This PR also addresses the issue #13 in the repository, resolving the [NASA] Display Error Codes problem.

[![Add Blueprint to Home Assistant](https://community-assets.home-assistant.io/original/4X/d/7/6/d7625545838a4970873f3a996172212440b7e0ae.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https://raw.githubusercontent.com/omerfaruk-aran/esphome_samsung_ac_blueprint/main/blueprints/automation/esphome_samsung_ac/notification_blueprint.yaml)

Screenshot:
![Screenshot1](https://github.com/omerfaruk-aran/esphome_samsung_ac_blueprint/raw/main/images/0%20error%20code.jpg)
![Screenshot2](https://github.com/omerfaruk-aran/esphome_samsung_ac_blueprint/raw/main/images/101%20error%20code.jpg)
![Screenshot3](https://github.com/omerfaruk-aran/esphome_samsung_ac_blueprint/raw/main/images/201%20error%20code.jpg)

- Resolves #13 

We look forward to your feedback on this PR!