### PR TITLE
Fix: Resolve issue #187 - Handle true/false values for swing control

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -283,11 +283,11 @@ async def to_code(config):
         # setup capabilities
         capabilities = device.get(CONF_CAPABILITIES, config.get(CONF_CAPABILITIES, {}))
 
-        if capabilities.get(CONF_CAPABILITIES_VERTICAL_SWING):
-            cg.add(var_dev.set_supports_vertical_swing(True))
+        if CONF_CAPABILITIES_VERTICAL_SWING in capabilities:
+            cg.add(var_dev.set_supports_vertical_swing(capabilities[CONF_CAPABILITIES_VERTICAL_SWING]))
 
-        if capabilities.get(CONF_CAPABILITIES_HORIZONTAL_SWING):
-            cg.add(var_dev.set_supports_horizontal_swing(True))
+        if CONF_CAPABILITIES_HORIZONTAL_SWING in capabilities:
+            cg.add(var_dev.set_supports_horizontal_swing(capabilities[CONF_CAPABILITIES_HORIZONTAL_SWING]))
 
         none_added = False
         presets = capabilities.get(CONF_PRESETS, {})

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -478,8 +478,8 @@ namespace esphome
       }
 
     protected:
-      bool supports_horizontal_swing_{true};
-      bool supports_vertical_swing_{true};
+      bool supports_horizontal_swing_{false};
+      bool supports_vertical_swing_{false};
       std::vector<AltModeDesc> alt_modes;
 
       Protocol *protocol{nullptr};


### PR DESCRIPTION
- This PR resolves issue Resolves #187 by ensuring that both `true` and `false` values for horizontal and vertical swing control are properly handled. 

- Updated the `__init__.py` to pass both `true` and `false` values to the device.
- Set default values for `supports_horizontal_swing_` and `supports_vertical_swing_` to `false` in `samsung_ac_device.h`.

Tested and confirmed functionality.
