### PR TITLE
Add flow control pin 2

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -81,6 +81,7 @@ CONF_DEVICE_OUT_CONTROL_WATTMETER_ALL_UNIT_ACCUM = "outdoor_instantaneous_power"
 CONF_DEVICE_OUT_CONTROL_WATTMETER_1W_1MIN_SUM = "outdoor_cumulative_energy"
 CONF_DEVICE_OUT_SENSOR_CT1 = "outdoor_current"
 CONF_DEVICE_OUT_SENSOR_VOLTAGE = "outdoor_voltage"
+CONF_FLOW_CONTROL_PIN_2 = "flow_control_pin_2"
 
 
 CONF_CAPABILITIES = "capabilities"
@@ -326,6 +327,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(Samsung_AC),
             # cv.Optional(CONF_PAUSE, default=False): cv.boolean,
             cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_FLOW_CONTROL_PIN_2): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DEBUG_MQTT_HOST, default=""): cv.string,
             cv.Optional(CONF_DEBUG_MQTT_PORT, default=1883): cv.int_,
             cv.Optional(CONF_DEBUG_MQTT_USERNAME, default=""): cv.string,
@@ -352,6 +354,9 @@ async def to_code(config):
     if CONF_FLOW_CONTROL_PIN in config:
         pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
         cg.add(var.set_flow_control_pin(pin))
+    if CONF_FLOW_CONTROL_PIN_2 in config:
+        pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN_2])
+        cg.add(var.set_flow_control_pin_2(pin))
 
     for device_index, device in enumerate(config[CONF_DEVICES]):
         var_dev = cg.new_Pvariable(

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -18,6 +18,10 @@ namespace esphome
       {
         this->flow_control_pin_->setup();
       }
+      if (this->flow_control_pin_2_ != nullptr)
+      {
+        this->flow_control_pin_2_->setup();
+      }
     }
 
     void Samsung_AC::update()
@@ -90,6 +94,7 @@ namespace esphome
     {
       ESP_LOGCONFIG(TAG, "Samsung_AC:");
       LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
+      LOG_PIN("  Flow Control Pin 2: ", this->flow_control_pin_2_);
     }
 
     void Samsung_AC::publish_data(std::vector<uint8_t> &data)
@@ -100,6 +105,10 @@ namespace esphome
         ESP_LOGD(TAG, "switching flow_control_pin to write");
         this->flow_control_pin_->digital_write(true);
         }
+      if (this->flow_control_pin_2_ != nullptr) {
+        ESP_LOGD(TAG, "switching flow_control_pin_2 to write");
+        this->flow_control_pin_2_->digital_write(true);
+        }
 
       this->write_array(data);
       this->flush();
@@ -107,6 +116,10 @@ namespace esphome
       if (this->flow_control_pin_ != nullptr) {
         ESP_LOGD(TAG, "switching flow_control_pin to read");
         this->flow_control_pin_->digital_write(false);
+        }
+      if (this->flow_control_pin_2_ != nullptr) {
+        ESP_LOGD(TAG, "switching flow_control_pin_2 to read");
+        this->flow_control_pin_2_->digital_write(false);
         }
     }
 

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -55,6 +55,11 @@ namespace esphome
         this->flow_control_pin_ = flow_control_pin;
       }
 
+      void set_flow_control_pin_2(GPIOPin *flow_control_pin)
+      {
+        this->flow_control_pin_2_ = flow_control_pin;
+      }
+
       void set_debug_mqtt(std::string host, int port, std::string username, std::string password)
       {
         debug_mqtt_host = host;
@@ -246,6 +251,7 @@ namespace esphome
 
       // settings from yaml
       GPIOPin *flow_control_pin_{nullptr};
+      GPIOPin *flow_control_pin_2_{nullptr};
       std::string debug_mqtt_host = "";
       uint16_t debug_mqtt_port = 1883;
       std::string debug_mqtt_username = "";

--- a/example.yaml
+++ b/example.yaml
@@ -65,6 +65,7 @@ samsung_ac:
   # For half duplex RS485 board with DI, DE, RE, and RO pins, you have to control read/write with control pin
   # see https://microcontrollerslab.com/rs485-serial-communication-esp32-esp8266-tutorial/ for wiring
   #flow_control_pin: GPIO4
+  #flow_control_pin_2: GPIO4
 
   # Capabilities configure the features that all devices of your AC system have (all parts of this section are optional). 
   # All capabilities are off by default, you need to enable only those your devices have.


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?

- [ ] 🐞 Bug Fix
- [X] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes

This PR adds `flow_control_pin_2` with exactly the same behavior as `flow_control_pin`.

### 🚀 Purpose

The motivation here is to avoid local echo when using [Olimex ESP32-POE-ISO](https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO/open-source-hardware) + [MOD-RS485](https://www.olimex.com/Products/Modules/Interface/MOD-RS485/open-source-hardware). This hardware combination is commercially available like the M5Stack, but it additionally supports Ethernet connectivity.

The MOD-RS485 board is an [ADM3483ARZ](https://www.analog.com/media/en/technical-documentation/data-sheets/adm3483_3485_3488_3490_3491.pdf) connected as follows:

| ESP32-POE-ISO | MOD-RS485 
| ------------- | ----------
| `3.3V`        | `3.3V`
| `GND`         | `GND`
| `GPIO4`       | `TXD`
| `GPIO36`      | `RXD`
| `GPIO14`      | `DE`
| `GPIO5`       | `/RE`

`DE` enables transmission, while `/RE` inhibits reception.

Configuring `flow_control_pin: GPIO14` works, but causes `samsung_ac` to receive its own transmission:

```
[W][samsung_ac:472]: publish packet #Packet Src:80.ff.00 Dst:20.00.01 {PacketInformation: 1;ProtocolVersion: 2;RetryCount: 0;PacketType: 1;DataType: 3;PacketNumber: 0}
[W][samsung_ac:472]:  > Enum 4111 = 1
[W][samsung_ac:102]: write 32001180ff00200001c013000141110128b734
[D][samsung_ac:105]: switching flow_control_pin to write
[D][samsung_ac:117]: switching flow_control_pin to read
[W][samsung_ac:853]: Request #Packet Src:80.ff.00 Dst:20.00.01 {PacketInformation: 1;ProtocolVersion: 2;RetryCount: 0;PacketType: 1;DataType: 3;PacketNumber: 0}
[W][samsung_ac:853]:  > Enum 4111 = 1
[W][samsung_ac:835]: found Ack for packet number 0
[W][samsung_ac:847]: Ack #Packet Src:20.00.01 Dst:80.ff.00 {PacketInformation: 1;ProtocolVersion: 2;RetryCount: 0;PacketType: 1;DataType: 6;PacketNumber: 0}
[W][samsung_ac:847]:  sent_packets size: 0
```

Note the `[samsung_ac:853]` lines, showing the transmitted packet being received by the transmitting device.

With this PR, configuring `flow_control_pin_2: GPIO5` prevents local echo:

```
[W][samsung_ac:472]: publish packet #Packet Src:80.ff.00 Dst:20.00.01 {PacketInformation: 1;ProtocolVersion: 2;RetryCount: 0;PacketType: 1;DataType: 3;PacketNumber: 0}
[W][samsung_ac:472]:  > Enum 4111 = 0
[W][samsung_ac:102]: write 32001180ff00200001c0130001411100389634
[D][samsung_ac:105]: switching flow_control_pin to write
[D][samsung_ac:109]: switching flow_control_pin_2 to write
[D][samsung_ac:117]: switching flow_control_pin to read
[D][samsung_ac:121]: switching flow_control_pin_2 to read
[W][samsung_ac:835]: found Ack for packet number 0
[W][samsung_ac:847]: Ack #Packet Src:20.00.01 Dst:80.ff.00 {PacketInformation: 1;ProtocolVersion: 2;RetryCount: 0;PacketType: 1;DataType: 6;PacketNumber: 0}
[W][samsung_ac:847]:  sent_packets size: 0
```

Avoiding local echo seems more correct, but it is unclear to me whether this is useful or necessary. (If this is in fact useless and unnecessary, please feel free to close this PR.) It would also obviously be possible to connect these two pins with a bodge wire or something, but given that these parts are otherwise ready to use together in their factory configuration, configuring both GPIO14 and GPIO5 to produce the same flow control signal seemed preferable.

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [X] Code compiles without errors 🧑‍💻
- [X] All tests pass successfully ✅
- [X] Changes have been tested on relevant devices 🛠️
- [X] Documentation has been updated (if necessary) 📖
- [X] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.6.1
- **Home Assistant Version**: n/a

### 🧩 Devices
- **Air Conditioner Type**:
  - [X] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AC009BNNDCH/AA
- **Outdoor Unit Model**: AJ020BXJ2CH/AA
- **ESP Device Model**: Olimex ESP32-POE-ISO + MOD-RS485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?

I compiled and ran `main`, then compiled and ran my branch.

---

## 🛠️ **YAML Configuration**
```yaml
esphome:
  name: esp32-poe-iso-hvac

esp32:
  board: esp32-poe-iso
  framework:
    type: esp-idf

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0
  power_pin: GPIO12

uart:
  tx_pin: GPIO4
  rx_pin: GPIO36
  baud_rate: 9600
  parity: EVEN

external_components:
  - source: github://willglynn/esphome_samsung_hvac_bus@add_flow_control_pin_2
    components: [samsung_ac]

samsung_ac:
  flow_control_pin: GPIO14
  flow_control_pin_2: GPIO5
  # …
```
