### PR TITLE
Fix custom fan and preset handling for ESPHome 2025.11.0 (fixes #313)

### DIFF
--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -15,9 +15,10 @@ namespace esphome
       climate::ClimateTraits traits;
 
       traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-      traits.set_visual_temperature_step(1.0f);
-      traits.set_visual_min_temperature(16.0f);
-      traits.set_visual_max_temperature(30.0f);
+
+      traits.set_visual_temperature_step(1);
+      traits.set_visual_min_temperature(16);
+      traits.set_visual_max_temperature(30);
 
       traits.set_supported_modes({climate::CLIMATE_MODE_OFF,
                                   climate::CLIMATE_MODE_AUTO,
@@ -31,10 +32,52 @@ namespace esphome
                                       climate::CLIMATE_FAN_LOW,
                                       climate::CLIMATE_FAN_AUTO});
 
-      traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF,
-                                        climate::CLIMATE_SWING_HORIZONTAL,
-                                        climate::CLIMATE_SWING_VERTICAL,
-                                        climate::CLIMATE_SWING_BOTH});
+      {
+        static const char *CUSTOM_FAN_MODES[] = {"Turbo"};
+        traits.set_supported_custom_fan_modes(CUSTOM_FAN_MODES);
+      }
+
+      {
+        auto supported = device->get_supported_alt_modes();
+        if (!supported->empty())
+        {
+          std::vector<const char *> custom_presets;
+
+          for (const AltModeDesc &mode : *supported)
+          {
+            auto preset = altmodename_to_preset(mode.name);
+            if (preset.has_value())
+            {
+              traits.add_supported_preset(preset.value());
+            }
+            else
+            {
+              custom_presets.push_back(mode.name.c_str());
+            }
+          }
+
+          if (!custom_presets.empty())
+          {
+            traits.set_supported_custom_presets(custom_presets);
+          }
+        }
+      }
+
+      {
+        bool h = device->supports_horizontal_swing();
+        bool v = device->supports_vertical_swing();
+
+        if (h || v)
+        {
+          traits.add_supported_swing_mode(climate::CLIMATE_SWING_OFF);
+          if (h)
+            traits.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
+          if (v)
+            traits.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
+          if (h && v)
+            traits.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
+        }
+      }
 
       return traits;
     }
@@ -50,7 +93,9 @@ namespace esphome
         request.target_temp = targetTempOpt.value();
 
       auto modeOpt = call.get_mode();
-      if (modeOpt.has_value())
+      const bool mode_changed = modeOpt.has_value();
+
+      if (mode_changed)
       {
         if (modeOpt.value() == climate::ClimateMode::CLIMATE_MODE_OFF)
         {
@@ -63,27 +108,31 @@ namespace esphome
       }
 
       auto fanmodeOpt = call.get_fan_mode();
+      const char *custom_fan = call.get_custom_fan_mode();
+
       if (fanmodeOpt.has_value())
       {
         request.fan_mode = climatefanmode_to_fanmode(fanmodeOpt.value());
       }
-
-      const char *customFanmode = call.get_custom_fan_mode();
-      if (customFanmode != nullptr)
+      else if (custom_fan != nullptr && custom_fan[0] != '\0')
       {
-        request.fan_mode = customfanmode_to_fanmode(std::string(customFanmode));
+        request.fan_mode = customfanmode_to_fanmode(custom_fan);
       }
-
+      else if (mode_changed)
+      {
+        FanMode auto_fan = climatefanmode_to_fanmode(climate::CLIMATE_FAN_AUTO);
+        request.fan_mode = auto_fan;
+      }
       auto presetOpt = call.get_preset();
       if (presetOpt.has_value())
       {
         set_alt_mode_by_name(request, preset_to_altmodename(presetOpt.value()));
       }
 
-      const char *customPreset = call.get_custom_preset();
-      if (customPreset != nullptr)
+      const char *custom_preset = call.get_custom_preset();
+      if (custom_preset != nullptr && custom_preset[0] != '\0')
       {
-        set_alt_mode_by_name(request, AltModeName(customPreset));
+        set_alt_mode_by_name(request, AltModeName(custom_preset));
       }
 
       auto swingModeOpt = call.get_swing_mode();
@@ -107,5 +156,41 @@ namespace esphome
       }
       request.alt_mode = mode->value;
     }
+
+    void Samsung_AC_Climate::apply_fanmode_from_device(FanMode value)
+    {
+      auto fanmode = fanmode_to_climatefanmode(value);
+      if (fanmode.has_value())
+      {
+        this->set_fan_mode_(*fanmode);
+        this->clear_custom_fan_mode_();
+      }
+      else
+      {
+        this->clear_custom_fan_mode_();
+
+        std::string custom = fanmode_to_custom_climatefanmode(value);
+        if (!custom.empty())
+        {
+          this->set_custom_fan_mode_(custom.c_str());
+        }
+      }
+    }
+
+    void Samsung_AC_Climate::apply_altmode_from_device(const AltModeDesc &mode)
+    {
+      auto preset = altmodename_to_preset(mode.name);
+      if (preset.has_value())
+      {
+        this->set_preset_(*preset);
+        this->clear_custom_preset_();
+      }
+      else
+      {
+        this->clear_custom_preset_();
+        this->set_custom_preset_(mode.name.c_str());
+      }
+    }
+
   } // namespace samsung_ac
 } // namespace esphome

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -25,6 +25,9 @@ namespace esphome
     public:
       climate::ClimateTraits traits();
       void control(const climate::ClimateCall &call);
+      void apply_fanmode_from_device(FanMode value);
+      void apply_altmode_from_device(const AltModeDesc &mode);
+
       Samsung_AC_Device *device;
 
     protected:
@@ -383,15 +386,7 @@ namespace esphome
       {
         if (climate != nullptr)
         {
-          auto fanmode = fanmode_to_climatefanmode(value);
-          if (fanmode.has_value())
-          {
-            climate->fan_mode = fanmode;
-          }
-          else
-          {
-            climate->fan_mode.reset();
-          }
+          climate->apply_fanmode_from_device(value);
           climate->publish_state();
         }
       }
@@ -409,15 +404,8 @@ namespace esphome
             return;
           }
 
-          auto preset = altmodename_to_preset(mode->name);
-          if (preset)
-          {
-            climate->preset = preset.value();
-          }
-          else
-          {
-             ESP_LOGW(TAG, "Alt mode %s has no matching preset", mode->name.c_str());
-          }
+          climate->apply_altmode_from_device(*mode);
+          
           climate->publish_state();
         }
       }


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [x] ✨ New Feature
- [x] 🔨 Code Improvement
- [ ] 📚 Documentation Update

This PR restores proper handling of custom fan modes (e.g. **Turbo**) and custom presets (e.g. **WindFree**) on ESPHome **2025.11.0**, ensuring that:
- The device behaviour and the Home Assistant UI stay in sync.
- The climate entity correctly reflects custom fan/preset state instead of falling back to `None`.

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. Reworked `Samsung_AC_Climate::traits()` to use the new ESPHome 2025.11.0 climate API (`add_feature_flags`, `add_supported_*`, `set_supported_custom_*`).
2. Added helper methods to correctly map device state back into the climate entity:
   - `apply_fanmode_from_device(FanMode value)`
   - `apply_altmode_from_device(AltMode value)`
3. Updated `update_fanmode()` and `update_altmode()` in `Samsung_AC_Device` to:
   - Set standard fan/preset values when possible.
   - Fallback to custom fan/preset where appropriate.
   - Avoid resetting UI state to `None` while the device remains in Turbo / WindFree mode.

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: #313  

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅ *(manual functional testing on real hardware)*
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.11.0
- **Home Assistant Version**: 2025.11.3

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: `AR09TXFCAWKNEU`
- **Outdoor Unit Model**: `AJ050TXJ2KH/EA`
- **ESP Device Model**: `M5STACK ATOM Lite + M5STACK RS-485`
- **Wiring Configuration**: `F1/F2`

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. Compiled and flashed the node with ESPHome **2025.11.0**.
2. Verified that:
   - Selecting **Turbo** in Home Assistant:
     - Sends the correct `fan_mode` to the NASA bus.
     - Updates the climate entity so that the custom fan mode is shown instead of falling back to `None`.
   - Toggling **WindFree** / alternate modes via preset & custom preset:
     - Activates the correct alt mode on the device.
     - Keeps the preset/custom preset in sync in Home Assistant (no automatic reset to `None`).
3. Changed between different standard fan modes (**Auto / Low / Medium / High**) and confirmed:
   - The device responds correctly.
   - The climate entity always reflects the actual fan state.
4. Power-cycled the ESP device and confirmed that:
   - The restored fan/preset state from the bus is correctly mapped back into the climate entity using the new helper methods.

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->
Key checks:
- No compile-time errors on ESPHome **2025.11.0**.
- No runtime exceptions in the ESPHome logs when switching fan modes or presets.
- Home Assistant logbook shows correct mode changes when using Turbo / WindFree.

---
