### PR TITLE
Use 0x4204 as indoor room temperature source for NASA units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 test.exe
 .pio/
 .venv/
+.venvs/
 .vscode/
 src/
 platformio.ini

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1230,7 +1230,7 @@ namespace esphome
             case 0x808d:
             case 0x8248:
             case 0x823f:
-            case 0x4204:
+            case 0x4203:
             case 0x4006:
             {
                 // ESP_LOGW(TAG, "s:%s d:%s NoMap %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -80,7 +80,7 @@ namespace esphome
             ENUM_in_louver_hl_swing = 0x4011,
             ENUM_in_louver_lr_swing = 0x407e,
             ENUM_in_state_humidity_percent = 0x4038,
-            VAR_in_temp_room_f = 0x4203,
+            VAR_in_temp_room_f = 0x4204,
             VAR_in_temp_target_f = 0x4201,
             VAR_in_temp_water_outlet_target_f = 0x4247,
             VAR_in_temp_water_tank_f = 0x4237,


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix  
- [ ] ✨ New Feature  
- [ ] 🔨 Code Improvement  
- [ ] 📚 Documentation Update  

This PR changes the NASA protocol’s “indoor room temperature” source from register `0x4203` to `0x4204`, as discussed in #225.  
The goal is to have the `current_temperature` reported by the climate entity match the temperature shown directly on the AC and in SmartThings.

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. Update `VAR_in_temp_room_f` in `components/samsung_ac/protocol_nasa.h` from `0x4203` to `0x4204`.
2. Rebuild and verify that the climate entity now uses the new register for `current_temperature`.
3. No changes to YAML configuration or user-visible options.

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes:  
Related: #225  

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻  
- [x] Changes have been tested on relevant devices 🛠️  
- [ ] All tests pass successfully ✅  
- [ ] Documentation has been updated (if necessary) 📖  
- [x] This PR is ready for review 🔍  

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.11.2  
- **Home Assistant Version**:  2025.11.3  

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AR09TXFCAWKNEU (WindFree)  
- **Outdoor Unit Model**: AJ050TXJ2KH/EA  
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485  
- **Wiring Configuration**: F1/F2  

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. Build the firmware with ESPHome 2025.11.2 using the updated component.
2. Flash to an ESP device connected to a NASA WindFree indoor unit.
3. Compare `current_temperature` in Home Assistant with:
   - The temperature shown on the indoor unit’s display.
   - The temperature reported by SmartThings (where available).
4. Confirm that the value from `0x4204` better matches the real indoor temperature than the previous `0x4203` mapping.

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->
_No log changes; climate updates continue to be reported normally in ESPHome logs._
