### PR TITLE
Ensure message delivery for NASA packets

### DIFF
--- a/components/samsung_ac/log.cpp
+++ b/components/samsung_ac/log.cpp
@@ -1,0 +1,10 @@
+namespace esphome
+{
+    namespace samsung_ac
+    {
+        bool debug_log_raw_bytes = false;
+        bool debug_log_messages = false;
+        bool debug_log_undefined_messages = false;
+
+    } // namespace samsung_ac
+} // namespace esphome

--- a/components/samsung_ac/log.h
+++ b/components/samsung_ac/log.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "util.h"
+
+#define LOGV(...) ESP_LOGV(TAG, __VA_ARGS__)
+#define LOGD(...) ESP_LOGD(TAG, __VA_ARGS__)
+#define LOGI(...) ESP_LOGI(TAG, __VA_ARGS__)
+#define LOGW(...) ESP_LOGW(TAG, __VA_ARGS__)
+#define LOGE(...) ESP_LOGE(TAG, __VA_ARGS__)
+#define LOGC(...) ESP_LOGCONFIG(TAG, __VA_ARGS__)
+
+#define LOG_STATE(...) LOGI(__VA_ARGS__)
+#define LOG_RAW_SEND(inter, ...) ({ if (debug_log_raw_bytes) LOGW("<< +%d: %s", inter, bytes_to_hex(__VA_ARGS__).c_str()); })
+#define LOG_RAW(inter, ...) ({ if (debug_log_raw_bytes) LOGD(">> +%d: %s", inter, bytes_to_hex(__VA_ARGS__).c_str()); })
+#define LOG_RAW_DISCARDED(inter, ...) ({if (debug_log_raw_bytes) LOGV(">> +%d: %s", inter, bytes_to_hex(__VA_ARGS__).c_str()); })
+#define LOG_PACKET_SEND(msg, packet) ({ if (debug_log_messages) LOGI("%s: %s", msg, packet.to_string().c_str()); })
+#define LOG_PACKET_RECV(msg, packet) ({ if (debug_log_messages) LOGD("%s: %s", msg, packet.to_string().c_str()); })
+
+namespace esphome
+{
+    namespace samsung_ac
+    {
+        extern bool debug_log_messages;
+        extern bool debug_log_undefined_messages;
+        extern bool debug_log_raw_bytes;
+
+    } // namespace samsung_ac
+} // namespace esphome

--- a/components/samsung_ac/protocol.cpp
+++ b/components/samsung_ac/protocol.cpp
@@ -1,6 +1,6 @@
-#include "esphome/core/log.h"
 #include "protocol.h"
 #include "util.h"
+#include "log.h"
 #include "protocol_nasa.h"
 #include "protocol_non_nasa.h"
 
@@ -8,36 +8,38 @@ namespace esphome
 {
     namespace samsung_ac
     {
-        bool debug_log_raw_bytes = false;
         bool non_nasa_keepalive = false;
-        bool debug_log_undefined_messages = false;
-        bool debug_log_messages = false;
 
         ProtocolProcessing protocol_processing = ProtocolProcessing::Auto;
 
+        uint16_t skip_data(std::vector<uint8_t> &data, int from)
+        {
+            // Skip over filler data or broken packets
+            // Example:
+            // 320037d8fedbff81cb7ffbfd808d00803f008243000082350000805e008031008248ffff801a0082d400000b6a34 f9f6f1f9f9 32000e200002
+            // Note that first part is a mangled packet, then regular filler data, then start of a new packet
+            // and that one new proper packet will continue with the next data read
+
+            // find next value of 0x32, and retry with that one
+            return std::find(data.begin() + from, data.end(), 0x32) - data.begin();
+        }
+
         // This functions is designed to run after a new value was added
         // to the data vector. One by one.
-        DataResult process_data(std::vector<uint8_t> &data, MessageTarget *target)
+        DecodeResult process_data(std::vector<uint8_t> &data, MessageTarget *target)
         {
-            if (data.size() > 1500)
-            {
-                ESP_LOGV(TAG, "current packat exceeds the size limits: %s", bytes_to_hex(data).c_str());
-                return DataResult::Clear;
-            }
+            if (*data.begin() != 0x32)
+                return { DecodeResultType::Discard, skip_data(data, 0) };
+
+
+            DecodeResult  result = { DecodeResultType::Fill, 0 };
 
             // Check if its a decodeable NonNASA packat
-            DecodeResult result = DecodeResult::Ok;
-
             if (protocol_processing == ProtocolProcessing::Auto || protocol_processing == ProtocolProcessing::NonNASA)
             {
                 result = try_decode_non_nasa_packet(data);
-                if (result == DecodeResult::Ok)
+                if (result.type == DecodeResultType::Processed)
                 {
-                    if (debug_log_raw_bytes)
-                    {
-                        ESP_LOGW(TAG, "RAW: %s", bytes_to_hex(data).c_str());
-                    }
-
                     // Non-NASA protocol confirmed, use for future packets
                     if (protocol_processing == ProtocolProcessing::Auto)
                     {
@@ -45,54 +47,36 @@ namespace esphome
                     }
 
                     process_non_nasa_packet(target);
-                    return DataResult::Clear;
+                    return result;
                 }
             }
-
-            if (protocol_processing == ProtocolProcessing::Auto || protocol_processing == ProtocolProcessing::NASA)
+            if (protocol_processing == ProtocolProcessing::NonNASA)
             {
-                result = try_decode_nasa_packet(data);
-                if (result == DecodeResult::Ok)
+                if (result.type == DecodeResultType::Discard)
                 {
-                    if (debug_log_raw_bytes)
-                    {
-                        ESP_LOGW(TAG, "RAW: %s", bytes_to_hex(data).c_str());
-                    }
-
-                    // NASA protocol confirmed, use for future packets
-                    if (protocol_processing == ProtocolProcessing::Auto)
-                    {
-                        protocol_processing = ProtocolProcessing::NASA;
-                    }
-
-                    process_nasa_packet(target);
-                    return DataResult::Clear;
+                    return { DecodeResultType::Discard, skip_data(data, 1) };
                 }
+                return result;
             }
 
-            if (result == DecodeResult::SizeDidNotMatch || result == DecodeResult::UnexpectedSize)
-            {
-                return DataResult::Fill;
-            }
+            // fallback to nasa
 
-            if (debug_log_raw_bytes)
+            result = try_decode_nasa_packet(data);
+            if (result.type == DecodeResultType::Processed)
             {
-                ESP_LOGV(TAG, "RAW: %s", bytes_to_hex(data).c_str());
-            }
+                // NASA protocol confirmed, use for future packets
+                if (protocol_processing == ProtocolProcessing::Auto)
+                {
+                    protocol_processing = ProtocolProcessing::NASA;
+                }
 
-            if (result == DecodeResult::InvalidStartByte)
-            {
-                ESP_LOGV(TAG, "invalid start byte: %s", bytes_to_hex(data).c_str());
+                process_nasa_packet(target);
             }
-            else if (result == DecodeResult::InvalidEndByte)
+            if (result.type == DecodeResultType::Discard)
             {
-                ESP_LOGV(TAG, "invalid end byte: %s", bytes_to_hex(data).c_str());
+                return { DecodeResultType::Discard, skip_data(data, 1) };
             }
-            else if (result == DecodeResult::CrcError)
-            {
-                // is logged within decoder
-            }
-            return DataResult::Clear;
+            return result;
         }
 
         bool is_nasa_address(const std::string &address)

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -8,19 +8,19 @@ namespace esphome
 {
     namespace samsung_ac
     {
-        extern bool debug_log_raw_bytes;
         extern bool non_nasa_keepalive;
-        extern bool debug_log_undefined_messages;
-        extern bool debug_log_messages;
 
-        enum class DecodeResult
+        enum class DecodeResultType
         {
-            Ok = 0,
-            InvalidStartByte = 1,
-            InvalidEndByte = 2,
-            SizeDidNotMatch = 3,
-            UnexpectedSize = 4,
-            CrcError = 5
+            Fill = 1,
+            Discard = 2,
+            Processed = 3
+        };
+
+        struct DecodeResult
+        {
+            DecodeResultType type;
+            uint16_t bytes; // when Processed
         };
 
         enum class Mode
@@ -74,7 +74,8 @@ namespace esphome
         {
         public:
             virtual uint32_t get_miliseconds() = 0;
-            virtual void publish_data(std::vector<uint8_t> &data) = 0;
+            virtual void publish_data(uint8_t id, std::vector<uint8_t> &&data) = 0;
+            virtual void ack_data(uint8_t id) = 0;
             virtual void register_address(const std::string address) = 0;
             virtual void set_power(const std::string address, bool value) = 0;
             virtual void set_automatic_cleaning(const std::string address, bool value) = 0;
@@ -132,13 +133,7 @@ namespace esphome
 
         extern ProtocolProcessing protocol_processing;
 
-        enum class DataResult
-        {
-            Fill = 0,
-            Clear = 1
-        };
-
-        DataResult process_data(std::vector<uint8_t> &data, MessageTarget *target);
+        DecodeResult process_data(std::vector<uint8_t> &data, MessageTarget *target);
 
         Protocol *get_protocol(const std::string &address);
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -1,8 +1,8 @@
 #include <set>
-#include "esphome/core/log.h"
 #include "esphome/core/util.h"
 #include "esphome/core/hal.h"
 #include "util.h"
+#include "log.h"
 #include "protocol_nasa.h"
 #include "debug_mqtt.h"
 
@@ -26,10 +26,10 @@ namespace esphome
             return value - (int)65535 /*uint16 max*/ - 1.0;
         }
 
-#define LOG_MESSAGE(message_name, temp, source, dest)                                                             \
-    if (debug_log_messages)                                                                                       \
-    {                                                                                                             \
-        ESP_LOGW(TAG, "s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), static_cast<double>(temp)); \
+#define LOG_MESSAGE(message_name, temp, source, dest)                                                         \
+    if (debug_log_messages)                                                                                   \
+    {                                                                                                         \
+        LOG_STATE("s:%s d:%s " #message_name " %g", source.c_str(), dest.c_str(), static_cast<double>(temp)); \
     }
 
         uint16_t crc16(std::vector<uint8_t> &data, int startIndex, int length)
@@ -143,7 +143,7 @@ namespace esphome
             case Structure:
                 if (capacity != 1)
                 {
-                    ESP_LOGE(TAG, "structure messages can only have one message but is %d", capacity);
+                    LOGE("structure messages can only have one message but is %d", capacity);
                     return set;
                 }
                 Buffer buffer;
@@ -156,7 +156,7 @@ namespace esphome
                 set.structure = buffer;
                 break;
             default:
-                ESP_LOGE(TAG, "Unkown type");
+                LOGE("Unkown type");
             }
 
             return set;
@@ -191,7 +191,7 @@ namespace esphome
                 }
                 break;
             default:
-                ESP_LOGE(TAG, "Unkown type");
+                LOGE("Unkown type");
             }
         }
 
@@ -213,8 +213,6 @@ namespace esphome
         }
 
         static int _packetCounter = 0;
-
-        std::vector<PacketInfo> sent_packets;
 
         /*
                 class OutgoingPacket
@@ -256,31 +254,42 @@ namespace esphome
             packet.command.packetInformation = true;
             packet.command.packetType = PacketType::Normal;
             packet.command.dataType = dataType;
+            if (_packetCounter == 0)
+                _packetCounter++; // skip 0
             packet.command.packetNumber = _packetCounter++;
             return packet;
         }
 
         DecodeResult Packet::decode(std::vector<uint8_t> &data)
         {
-            if (data[0] != 0x32)
-                return DecodeResult::InvalidStartByte;
+            const uint16_t size = (uint16_t)data[1] << 8 | (uint16_t)data[2];
 
-            if (data.size() < 16 || data.size() > 1500)
-                return DecodeResult::UnexpectedSize;
+            if (data.size() < 4)
+            {
+                return {DecodeResultType::Fill};
+            }
+            if (size > 1500)
+            {
+                LOGW("Packet exceeds size limits: %s", bytes_to_hex(data).c_str());
+                return {DecodeResultType::Discard};
+            }
 
-            int size = (int)data[1] << 8 | (int)data[2];
-            if (size + 2 != data.size())
-                return DecodeResult::SizeDidNotMatch;
+            if (size + 2 > data.size()) // need more data
+                return {DecodeResultType::Fill};
 
-            if (data[data.size() - 1] != 0x34)
-                return DecodeResult::InvalidEndByte;
+
+            if (data[size + 1] != 0x34)
+            {
+                LOGW("invalid end byte: %s", bytes_to_hex(data).c_str());
+                return {DecodeResultType::Discard};
+            }
 
             uint16_t crc_actual = crc16(data, 3, size - 4);
-            uint16_t crc_expected = (int)data[data.size() - 3] << 8 | (int)data[data.size() - 2];
+            uint16_t crc_expected = (int)data[size - 1] << 8 | (int)data[size];
             if (crc_expected != crc_actual)
             {
-                ESP_LOGW(TAG, "NASA: invalid crc - got %d but should be %d: %s", crc_actual, crc_expected, bytes_to_hex(data).c_str());
-                return DecodeResult::CrcError;
+                LOGW("NASA: invalid crc - got %d but should be %d: %s", crc_actual, crc_expected, bytes_to_hex(data).c_str());
+                return {DecodeResultType::Discard};
             }
 
             unsigned int cursor = 3;
@@ -305,7 +314,7 @@ namespace esphome
                 cursor += set.size;
             }
 
-            return DecodeResult::Ok;
+            return {DecodeResultType::Processed, (uint16_t)(size + 2)};
         };
 
         std::vector<uint8_t> Packet::encode()
@@ -377,104 +386,146 @@ namespace esphome
             }
         }
 
+        void NasaProtocol::protocol_update(MessageTarget *target)
+        {
+            for (const auto& pair : outgoing_queue_) {
+                const std::string &address = pair.first;
+                const ProtocolRequest &request = pair.second;
+                Packet packet = Packet::createa_partial(Address::parse(address), DataType::Request);
+
+                if (request.mode)
+                {
+                    MessageSet mode(MessageNumber::ENUM_in_operation_mode);
+                    mode.value = (int)request.mode.value();
+                    packet.messages.push_back(mode);
+                }
+
+                if (request.waterheatermode)
+                {
+                    MessageSet waterheatermode(MessageNumber::ENUM_in_water_heater_mode);
+                    waterheatermode.value = (int)request.waterheatermode.value();
+                    packet.messages.push_back(waterheatermode);
+                }
+
+                if (request.power)
+                {
+                    MessageSet power(MessageNumber::ENUM_in_operation_power);
+                    power.value = request.power.value() ? 1 : 0;
+                    packet.messages.push_back(power);
+                }
+
+                if (request.automatic_cleaning)
+                {
+                    MessageSet automatic_cleaning(MessageNumber::ENUM_in_operation_automatic_cleaning);
+                    automatic_cleaning.value = request.automatic_cleaning.value() ? 1 : 0;
+                    packet.messages.push_back(automatic_cleaning);
+                }
+
+                if (request.water_heater_power)
+                {
+                    MessageSet waterheaterpower(MessageNumber::ENUM_in_water_heater_power);
+                    waterheaterpower.value = request.water_heater_power.value() ? 1 : 0;
+                    packet.messages.push_back(waterheaterpower);
+                }
+
+                if (request.target_temp)
+                {
+                    MessageSet targettemp(MessageNumber::VAR_in_temp_target_f);
+                    targettemp.value = request.target_temp.value() * 10.0;
+                    packet.messages.push_back(targettemp);
+                }
+
+                if (request.water_outlet_target)
+                {
+                    MessageSet wateroutlettarget(MessageNumber::VAR_in_temp_water_outlet_target_f);
+                    wateroutlettarget.value = request.water_outlet_target.value() * 10.0;
+                    packet.messages.push_back(wateroutlettarget);
+                }
+
+                if (request.target_water_temp)
+                {
+                    MessageSet targetwatertemp(MessageNumber::VAR_in_temp_water_heater_target_f);
+                    targetwatertemp.value = request.target_water_temp.value() * 10.0;
+                    packet.messages.push_back(targetwatertemp);
+                }
+
+                if (request.fan_mode)
+                {
+                    MessageSet fanmode(MessageNumber::ENUM_in_fan_mode);
+                    fanmode.value = fanmode_to_nasa_fanmode(request.fan_mode.value());
+                    packet.messages.push_back(fanmode);
+                }
+
+                if (request.alt_mode)
+                {
+                    MessageSet altmode(MessageNumber::ENUM_in_alt_mode);
+                    altmode.value = request.alt_mode.value();
+                    packet.messages.push_back(altmode);
+                }
+
+                if (request.swing_mode)
+                {
+                    MessageSet hl_swing(MessageNumber::ENUM_in_louver_hl_swing);
+                    hl_swing.value = static_cast<uint8_t>(request.swing_mode.value()) & 1;
+                    packet.messages.push_back(hl_swing);
+
+                    MessageSet lr_swing(MessageNumber::ENUM_in_louver_lr_swing);
+                    lr_swing.value = (static_cast<uint8_t>(request.swing_mode.value()) >> 1) & 1;
+                    packet.messages.push_back(lr_swing);
+                }
+
+                if (packet.messages.size() == 0)
+                    return;
+
+                LOG_PACKET_SEND("Publish packet", packet);
+
+                target->publish_data(packet.command.packetNumber, packet.encode());
+            }
+            outgoing_queue_.clear();
+        }
+
         void NasaProtocol::publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request)
         {
-            Packet packet = Packet::createa_partial(Address::parse(address), DataType::Request);
+            ProtocolRequest &queued = outgoing_queue_[address];
 
             if (request.mode)
             {
                 request.power = true; // ensure system turns on when mode is set
-
-                MessageSet mode(MessageNumber::ENUM_in_operation_mode);
-                mode.value = (int)request.mode.value();
-                packet.messages.push_back(mode);
+                queued.mode = request.mode;
             }
 
             if (request.waterheatermode)
             {
                 request.water_heater_power = true; // ensure system turns on when mode is set
-
-                MessageSet waterheatermode(MessageNumber::ENUM_in_water_heater_mode);
-                waterheatermode.value = (int)request.waterheatermode.value();
-                packet.messages.push_back(waterheatermode);
+                queued.waterheatermode = request.waterheatermode;
             }
 
             if (request.power)
-            {
-                MessageSet power(MessageNumber::ENUM_in_operation_power);
-                power.value = request.power.value() ? 1 : 0;
-                packet.messages.push_back(power);
-            }
+                queued.power = request.power;
 
             if (request.automatic_cleaning)
-            {
-                MessageSet automatic_cleaning(MessageNumber::ENUM_in_operation_automatic_cleaning);
-                automatic_cleaning.value = request.automatic_cleaning.value() ? 1 : 0;
-                packet.messages.push_back(automatic_cleaning);
-            }
+                queued.automatic_cleaning = request.automatic_cleaning;
 
             if (request.water_heater_power)
-            {
-                MessageSet waterheaterpower(MessageNumber::ENUM_in_water_heater_power);
-                waterheaterpower.value = request.water_heater_power.value() ? 1 : 0;
-                packet.messages.push_back(waterheaterpower);
-            }
+                queued.water_heater_power = request.water_heater_power;
 
             if (request.target_temp)
-            {
-                MessageSet targettemp(MessageNumber::VAR_in_temp_target_f);
-                targettemp.value = request.target_temp.value() * 10.0;
-                packet.messages.push_back(targettemp);
-            }
+                queued.target_temp = request.target_temp;
 
             if (request.water_outlet_target)
-            {
-                MessageSet wateroutlettarget(MessageNumber::VAR_in_temp_water_outlet_target_f);
-                wateroutlettarget.value = request.water_outlet_target.value() * 10.0;
-                packet.messages.push_back(wateroutlettarget);
-            }
+                queued.water_outlet_target = request.water_outlet_target;
 
             if (request.target_water_temp)
-            {
-                MessageSet targetwatertemp(MessageNumber::VAR_in_temp_water_heater_target_f);
-                targetwatertemp.value = request.target_water_temp.value() * 10.0;
-                packet.messages.push_back(targetwatertemp);
-            }
+                queued.target_water_temp = request.target_water_temp;
 
             if (request.fan_mode)
-            {
-                MessageSet fanmode(MessageNumber::ENUM_in_fan_mode);
-                fanmode.value = fanmode_to_nasa_fanmode(request.fan_mode.value());
-                packet.messages.push_back(fanmode);
-            }
+                queued.fan_mode = request.fan_mode;
 
             if (request.alt_mode)
-            {
-                MessageSet altmode(MessageNumber::ENUM_in_alt_mode);
-                altmode.value = request.alt_mode.value();
-                packet.messages.push_back(altmode);
-            }
+                queued.alt_mode = request.alt_mode;
 
             if (request.swing_mode)
-            {
-                MessageSet hl_swing(MessageNumber::ENUM_in_louver_hl_swing);
-                hl_swing.value = static_cast<uint8_t>(request.swing_mode.value()) & 1;
-                packet.messages.push_back(hl_swing);
-
-                MessageSet lr_swing(MessageNumber::ENUM_in_louver_lr_swing);
-                lr_swing.value = (static_cast<uint8_t>(request.swing_mode.value()) >> 1) & 1;
-                packet.messages.push_back(lr_swing);
-            }
-
-            if (packet.messages.size() == 0)
-                return;
-
-            ESP_LOGW(TAG, "publish packet %s", packet.to_string().c_str());
-
-            auto data = packet.encode();
-            target->publish_data(data);
-
-            sent_packets.push_back({packet, 0, millis()});
+                queued.swing_mode = request.swing_mode;
         }
 
         Mode operation_mode_to_mode(int value)
@@ -549,7 +600,7 @@ namespace esphome
         {
             if (debug_mqtt_connected())
             {
-                static const std::string topic_prefix = "samsung_ac/nasa/";
+                static const std::string topic_prefix = "samsung_ac/nasa/" + source;
                 std::string topic_suffix;
                 std::string payload;
 
@@ -799,7 +850,7 @@ namespace esphome
                 default:
                     if (debug_log_undefined_messages)
                     {
-                        ESP_LOGW(TAG, "Undefined s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+                        LOGW("Undefined s:%s d:%s %s", source.c_str(), dest.c_str(), message.to_string().c_str());
                     }
                     break;
                 }
@@ -808,7 +859,7 @@ namespace esphome
             }
         }
 
-        DecodeResult try_decode_nasa_packet(std::vector<uint8_t> data)
+        DecodeResult try_decode_nasa_packet(std::vector<uint8_t> &data)
         {
             return packet_.decode(data);
         }
@@ -817,62 +868,51 @@ namespace esphome
         {
             const auto source = packet_.sa.to_string();
             const auto dest = packet_.da.to_string();
+            const auto me = Address::get_my_address().to_string();
 
             target->register_address(source);
 
             if (debug_log_undefined_messages)
             {
-                ESP_LOGW(TAG, "MSG: %s", packet_.to_string().c_str());
+                LOG_PACKET_RECV("MSG: %s", packet_);
             }
 
             if (packet_.command.dataType == DataType::Ack)
             {
-                bool ack_found = false;
-                for (auto it = sent_packets.begin(); it != sent_packets.end(); ++it)
+                if (dest == me)
                 {
-                    if (it->packet.command.packetNumber == packet_.command.packetNumber)
-                    {
-                        ESP_LOGW(TAG, "found Ack for packet number %d", it->packet.command.packetNumber);
-                        sent_packets.erase(it);
-                        ack_found = true;
-                        break;
-                    }
+                    LOG_PACKET_SEND("Ack", packet_);
+                    target->ack_data(packet_.command.packetNumber);
                 }
-
-                if (!ack_found)
-                {
-                    ESP_LOGW(TAG, "Ack not found for packet number %d", packet_.command.packetNumber);
-                }
-
-                ESP_LOGW(TAG, "Ack %s sent_packets size: %d", packet_.to_string().c_str(), sent_packets.size());
                 return;
             }
 
             if (packet_.command.dataType == DataType::Request)
             {
-                ESP_LOGW(TAG, "Request %s", packet_.to_string().c_str());
+                LOG_PACKET_RECV("Request %s", packet_);
                 return;
             }
             if (packet_.command.dataType == DataType::Response)
             {
-                ESP_LOGW(TAG, "Response %s", packet_.to_string().c_str());
+                LOG_PACKET_RECV("Response %s", packet_);
                 return;
             }
             if (packet_.command.dataType == DataType::Write)
             {
-                ESP_LOGW(TAG, "Write %s", packet_.to_string().c_str());
+                LOG_PACKET_RECV("Write %s", packet_);
                 return;
             }
             if (packet_.command.dataType == DataType::Nack)
             {
-                ESP_LOGW(TAG, "Nack %s", packet_.to_string().c_str());
+                LOG_PACKET_RECV("Nack %s", packet_);
                 return;
             }
             if (packet_.command.dataType == DataType::Read)
             {
-                ESP_LOGW(TAG, "Read %s", packet_.to_string().c_str());
+                LOG_PACKET_RECV("Read %s", packet_);
                 return;
             }
+            LOG_PACKET_RECV("RECV", packet_);
 
             if (packet_.command.dataType != DataType::Notification)
                 return;
@@ -880,23 +920,6 @@ namespace esphome
             for (auto &message : packet_.messages)
             {
                 process_messageset(source, dest, message, target);
-            }
-
-            uint32_t now = millis();
-            for (auto &info : sent_packets)
-            {
-                if (now - info.last_sent_time > 1000 && info.retry_count < 3)
-                {
-                    info.retry_count++;
-                    info.last_sent_time = now;
-                    auto data = info.packet.encode();
-                    target->publish_data(data);
-                    ESP_LOGW(TAG, "Resending packet %d number of attempts: %d", info.packet.command.packetNumber, info.retry_count);
-                }
-                else if (info.retry_count >= 3)
-                {
-                    ESP_LOGW(TAG, "Packet %d failed after 3 attempts.", info.packet.command.packetNumber);
-                }
             }
         }
 
@@ -1173,19 +1196,19 @@ namespace esphome
             case 0x42d1: // VAR_IN_DUST_SENSOR_PM10_0_VALUE
                 if (debug_log_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM10_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                    LOGW("s:%s d:%s VAR_IN_DUST_SENSOR_PM10_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
                 }
                 break;   // Ingore cause not important
             case 0x42d2: // VAR_IN_DUST_SENSOR_PM2_5_VALUE
                 if (debug_log_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM2_5_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                    LOGW("s:%s d:%s VAR_IN_DUST_SENSOR_PM2_5_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
                 }
                 break;   // Ingore cause not important
             case 0x42d3: // VAR_IN_DUST_SENSOR_PM1_0_VALUE
                 if (debug_log_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s VAR_IN_DUST_SENSOR_PM1_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                    LOGW("s:%s d:%s VAR_IN_DUST_SENSOR_PM1_0_VALUE %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
                 }
                 break; // Ingore cause not important
 
@@ -1233,22 +1256,17 @@ namespace esphome
             case 0x4203:
             case 0x4006:
             {
-                // ESP_LOGW(TAG, "s:%s d:%s NoMap %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
+                // LOGW("s:%s d:%s NoMap %s %li", source.c_str(), dest.c_str(), long_to_hex((int)message.messageNumber).c_str(), message.value);
                 break; // message types which have no mapping in xml
             }
 
             default:
                 if (debug_log_undefined_messages)
                 {
-                    ESP_LOGW(TAG, "s:%s d:%s !! unknown %s", source.c_str(), dest.c_str(), message.to_string().c_str());
+                    LOGW("s:%s d:%s !! unknown %s", source.c_str(), dest.c_str(), message.to_string().c_str());
                 }
                 break;
             }
-        }
-
-        void NasaProtocol::protocol_update(MessageTarget *target)
-        {
-            // Unused for NASA protocol
         }
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <map>
 #include "protocol.h"
 
 namespace esphome
@@ -172,7 +173,7 @@ namespace esphome
             std::string to_string();
         };
 
-        DecodeResult try_decode_nasa_packet(std::vector<uint8_t> data);
+        DecodeResult try_decode_nasa_packet(std::vector<uint8_t> &data);
         void process_nasa_packet(MessageTarget *target);
 
         class NasaProtocol : public Protocol
@@ -182,6 +183,8 @@ namespace esphome
 
             void publish_request(MessageTarget *target, const std::string &address, ProtocolRequest &request) override;
             void protocol_update(MessageTarget *target) override;
+        protected:
+            std::map<std::string, ProtocolRequest> outgoing_queue_; // std::string address -> ProtocolRequest
         };
 
     } // namespace samsung_ac

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -2,9 +2,9 @@
 #include <map>
 #include <cmath>
 #include <string>
-#include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include "util.h"
+#include "log.h"
 #include "protocol_non_nasa.h"
 
 std::map<std::string, esphome::samsung_ac::NonNasaCommand20> last_command20s_;
@@ -159,21 +159,18 @@ namespace esphome
 
         DecodeResult NonNasaDataPacket::decode(std::vector<uint8_t> &data)
         {
-            if (data[0] != 0x32)
-                return DecodeResult::InvalidStartByte;
-
             if (data.size() != 14)
-                return DecodeResult::UnexpectedSize;
+                return { DecodeResultType::Discard };
 
             if (data[data.size() - 1] != 0x34)
-                return DecodeResult::InvalidEndByte;
+                return { DecodeResultType::Discard };
 
             auto crc_expected = build_checksum(data);
             auto crc_actual = data[data.size() - 2];
             if (crc_actual != build_checksum(data))
             {
-                ESP_LOGW(TAG, "NonNASA: invalid crc - got %d but should be %d: %s", crc_actual, crc_expected, bytes_to_hex(data).c_str());
-                return DecodeResult::CrcError;
+                LOGW("NonNASA: invalid crc - got %d but should be %d: %s", crc_actual, crc_expected, bytes_to_hex(data).c_str());
+                return { DecodeResultType::Discard };
             }
 
             src = long_to_hex(data[1]);
@@ -196,7 +193,7 @@ namespace esphome
                 if (command20.wind_direction == (NonNasaWindDirection)0)
                     command20.wind_direction = NonNasaWindDirection::Stop;
 
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             case NonNasaCommand::CmdC0: // outdoor unit data
             {
@@ -208,17 +205,17 @@ namespace esphome
                 commandC0.outdoor_unit_outdoor_temp_c = data[8] - 55;
                 commandC0.outdoor_unit_discharge_temp_c = data[10] - 55;
                 commandC0.outdoor_unit_condenser_mid_temp_c = data[11] - 55;
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             case NonNasaCommand::CmdC1: // outdoor unit data
             {
                 commandC1.outdoor_unit_sump_temp_c = data[8] - 55;
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             case NonNasaCommand::CmdC6:
             {
                 commandC6.control_status = data[4];
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             case NonNasaCommand::CmdF0: // outdoor unit data
             {
@@ -232,7 +229,7 @@ namespace esphome
                 commandF0.inverter_current_frequency_hz = data[7];
                 commandF0.outdoor_unit_bldc_fan = data[8] & 0b00000011; // not sure if correct, i have no ou with BLDC-fan
                 commandF0.outdoor_unit_error_code = data[10];
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             case NonNasaCommand::CmdF1: // outdoor unit eev-values
             {
@@ -240,7 +237,7 @@ namespace esphome
                 commandF1.outdoor_unit_EEV_B = (data[6] * 256) + data[7];
                 commandF1.outdoor_unit_EEV_C = (data[8] * 256) + data[9];
                 commandF1.outdoor_unit_EEV_D = (data[10] * 256) + data[11];
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             case NonNasaCommand::CmdF3: // power consumption
             {
@@ -254,14 +251,14 @@ namespace esphome
                 commandF3.inverter_voltage_v = (float)data[9] * 2;
                 // Power consumption of the outdoo unit inverter in W
                 commandF3.inverter_power_w = commandF3.inverter_current_a * commandF3.inverter_voltage_v;
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             default:
             {
                 commandRaw.length = data.size() - 4 - 1;
                 auto begin = data.begin() + 4;
                 std::copy(begin, begin + commandRaw.length, commandRaw.data);
-                return DecodeResult::Ok;
+                return { DecodeResultType::Processed, (uint16_t) data.size() };
             }
             }
         }
@@ -417,12 +414,12 @@ namespace esphome
 
             if (request.alt_mode)
             {
-                ESP_LOGW(TAG, "change altmode is currently not implemented");
+                LOGW("change altmode is currently not implemented");
             }
 
             if (request.swing_mode)
             {
-                ESP_LOGW(TAG, "change swingmode is currently not implemented");
+                LOGW("change swingmode is currently not implemented");
             }
 
             // Add to the queue with the current time
@@ -488,7 +485,7 @@ namespace esphome
             }
         }
 
-        DecodeResult try_decode_non_nasa_packet(std::vector<uint8_t> data)
+        DecodeResult try_decode_non_nasa_packet(std::vector<uint8_t> &data)
         {
             return nonpacket_.decode(data);
         }
@@ -501,15 +498,14 @@ namespace esphome
                 if (item.time_sent == 0)
                 {
                     item.time_sent = now;
-                    auto data = item.request.encode();
-                    target->publish_data(data);
+                    target->publish_data(0, item.request.encode());
                 }
             }
         }
 
         void send_register_controller(MessageTarget *target)
         {
-            ESP_LOGD(TAG, "Sending controller registration request...");
+            LOGD("Sending controller registration request...");
 
             // Registers our device as a "controller" with the outdoor unit. This will cause the
             // outdoor unit to poll us with a request_control message approximately every second,
@@ -533,14 +529,14 @@ namespace esphome
             data[12] = build_checksum(data);
 
             // Send now
-            target->publish_data(data);
+            target->publish_data(0, std::move(data));
         }
 
         void process_non_nasa_packet(MessageTarget *target)
         {
             if (debug_log_undefined_messages)
             {
-                ESP_LOGW(TAG, "MSG: %s", nonpacket_.to_string().c_str());
+                LOG_PACKET_RECV("RECV", nonpacket_);
             }
 
             target->register_address(nonpacket_.src);
@@ -610,7 +606,7 @@ namespace esphome
                 {
                     if (controller_registered == false)
                     {
-                        ESP_LOGD(TAG, "Controller registered");
+                        LOGD("Controller registered");
                         controller_registered = true;
                     }
                     if (indoor_unit_awake)
@@ -681,7 +677,7 @@ namespace esphome
                     // Both the outdoor and the indoor unit must be awake before we can send a command
                     indoor_unit_awake = false;
                     item.retry_count++;
-                    ESP_LOGD(TAG, "Device is likely sleeping, waking...");
+                    LOGD("Device is likely sleeping, waking...");
                     send_register_controller(target);
                     break;
                 }

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -203,7 +203,7 @@ namespace esphome
         extern bool controller_registered;
         extern bool indoor_unit_awake;
 
-        DecodeResult try_decode_non_nasa_packet(std::vector<uint8_t> data);
+        DecodeResult try_decode_non_nasa_packet(std::vector<uint8_t> &data);
         void process_non_nasa_packet(MessageTarget *target);
 
         class NonNasaProtocol : public Protocol

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -1,7 +1,7 @@
-#include "esphome/core/log.h"
 #include "samsung_ac.h"
 #include "debug_mqtt.h"
 #include "util.h"
+#include "log.h"
 #include <vector>
 
 namespace esphome
@@ -12,7 +12,7 @@ namespace esphome
     {
       if (debug_log_messages)
       {
-        ESP_LOGW(TAG, "setup");
+        LOGW("setup");
       }
       if (this->flow_control_pin_ != nullptr)
       {
@@ -24,7 +24,7 @@ namespace esphome
     {
       if (debug_log_messages)
       {
-        ESP_LOGW(TAG, "update");
+        LOGW("update");
       }
 
       for (const auto &pair : devices_)
@@ -43,7 +43,7 @@ namespace esphome
       // Waiting for first update before beginning processing data
       if (data_processing_init)
       {
-        ESP_LOGCONFIG(TAG, "Data Processing starting");
+        LOGC("Data Processing starting");
         data_processing_init = false;
       }
 
@@ -54,7 +54,7 @@ namespace esphome
           devices += ", ";
         devices += pair.second->address;
       }
-      ESP_LOGCONFIG(TAG, "Configured devices: %s", devices.c_str());
+      LOGC("Configured devices: %s", devices.c_str());
 
       std::string knownIndoor, knownOutdoor, knownOther;
       for (const auto &address : addresses_)
@@ -66,12 +66,12 @@ namespace esphome
         target += address;
       }
 
-      ESP_LOGCONFIG(TAG, "Discovered devices:");
-      ESP_LOGCONFIG(TAG, "  Outdoor: %s", (knownOutdoor.length() == 0 ? "-" : knownOutdoor.c_str()));
-      ESP_LOGCONFIG(TAG, "  Indoor:  %s", (knownIndoor.length() == 0 ? "-" : knownIndoor.c_str()));
+      LOGC("Discovered devices:");
+      LOGC("  Outdoor: %s", (knownOutdoor.length() == 0 ? "-" : knownOutdoor.c_str()));
+      LOGC("  Indoor:  %s", (knownIndoor.length() == 0 ? "-" : knownIndoor.c_str()));
       if (knownOther.length() > 0)
       {
-        ESP_LOGCONFIG(TAG, "  Other:   %s", knownOther.c_str());
+        LOGC("  Other:   %s", knownOther.c_str());
       }
     }
 
@@ -79,7 +79,7 @@ namespace esphome
     {
       if (find_device(device->address) != nullptr)
       {
-        ESP_LOGW(TAG, "There is already and device for address %s registered.", device->address.c_str());
+        LOGW("There is already and device for address %s registered.", device->address.c_str());
         return;
       }
 
@@ -88,25 +88,42 @@ namespace esphome
 
     void Samsung_AC::dump_config()
     {
-      ESP_LOGCONFIG(TAG, "Samsung_AC:");
+      LOGC("Samsung_AC:");
       LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
     }
 
-    void Samsung_AC::publish_data(std::vector<uint8_t> &data)
+    void Samsung_AC::publish_data(uint8_t id, std::vector<uint8_t> &&data) 
     {
-      ESP_LOGW(TAG, "write %s", bytes_to_hex(data).c_str());
+      const uint32_t now = millis();
 
-      if (this->flow_control_pin_ != nullptr) {
-        ESP_LOGD(TAG, "switching flow_control_pin to write");
-        this->flow_control_pin_->digital_write(true);
-        }
+      if (id == 0)
+      {
+        LOG_RAW_SEND(now-last_transmission_, data);
+        last_transmission_ = now;
+        this->before_write();
+        this->write_array(data);
+        this->flush();
+        this->after_write();
+        return;
+      }
 
-      this->write_array(data);
-      this->flush();
+      OutgoingData outData;
+      outData.id = id;
+      outData.data = std::move(data);
+      outData.nextRetry = 0;
+      outData.retries = 0;
+      outData.timeout = now + sendTimeout;
+      send_queue_.push_back(std::move(outData));
+    }
 
-      if (this->flow_control_pin_ != nullptr) {
-        ESP_LOGD(TAG, "switching flow_control_pin to read");
-        this->flow_control_pin_->digital_write(false);
+    void Samsung_AC::ack_data(uint8_t id)
+    {
+        if (!send_queue_.empty())
+        {
+          auto senddata = &send_queue_.front();
+          if (senddata->id == id) {
+            send_queue_.pop_front();
+          }
         }
     }
 
@@ -115,32 +132,17 @@ namespace esphome
       if (data_processing_init)
         return;
 
+      // if more data is expected, do not allow anything to be written
+      if (!read_data())
+        return;
+
+      // If there is no data we use the time to send
+      // And if written, break the loop
+      if (write_data())
+        return;
+
+      // Allow device protocols to perform recurring tasks when idle (at most every 200ms)
       const uint32_t now = millis();
-      if (!data_.empty() && (now - last_transmission_ >= 500))
-      {
-        ESP_LOGW(TAG, "Last transmission too long ago. Reset RX index.");
-        data_.clear();
-      }
-
-      while (available())
-      {
-        last_transmission_ = now;
-        uint8_t c;
-        if (!read_byte(&c))
-          continue;
-        if (data_.empty() && c != 0x32)
-          continue; // skip until start-byte found
-
-        data_.push_back(c);
-
-        if (process_data(data_, this) == DataResult::Clear)
-        {
-          data_.clear();
-          break; // wait for next loop
-        }
-      }
-
-      // Allow device protocols to perform recurring tasks (at most every 200ms)
       if (now - last_protocol_update_ >= 200)
       {
         last_protocol_update_ = now;
@@ -149,6 +151,99 @@ namespace esphome
           Samsung_AC_Device *device = pair.second;
           device->protocol_update(this);
         }
+      }
+    }
+
+    bool Samsung_AC::read_data()
+    {
+      // read as long as there is anything to read
+      while (available())
+      {
+        uint8_t c;
+        if (read_byte(&c))
+        {
+          data_.push_back(c);
+        }
+      }
+
+      if (data_.empty())
+        return true;
+
+      const uint32_t now = millis();
+
+      auto result = process_data(data_, this);
+      if (result.type == DecodeResultType::Fill)
+        return false;
+
+      if (result.type == DecodeResultType::Discard)
+      {
+        // collect more so that we can log all discarded bytes at once, but don't wait for too long
+        if (result.bytes == data_.size() && now-last_transmission_ < 1000)
+          return false;
+        LOG_RAW_DISCARDED(now-last_transmission_, data_, 0, result.bytes);
+      }
+      else
+      {
+        LOG_RAW(now-last_transmission_, data_, 0, result.bytes);
+      }
+
+      if (result.bytes == data_.size())
+        data_.clear();
+      else
+      {
+        std::move(data_.begin() + result.bytes, data_.end(), data_.begin());
+        data_.resize(data_.size() - result.bytes);
+      }
+      last_transmission_ = now;
+      return false;
+    }
+
+    bool Samsung_AC::write_data()
+    {
+      if (send_queue_.empty())
+        return false;
+
+      auto senddata = &send_queue_.front();
+
+      const uint32_t now = millis();
+      if (senddata->timeout <= now && senddata->retries >= minRetries) {
+        LOGE("Packet sending timeout %d after %d retries", senddata->id, senddata->retries);
+        send_queue_.pop_front();
+        return true;
+      }
+
+      if (now-last_transmission_ > silenceInterval && senddata->nextRetry < now)
+      {
+        if (senddata->nextRetry > 0){
+          LOGW("Retry sending packet %d", senddata->id);
+          senddata->retries++;
+        }
+
+        LOG_RAW_SEND(now-last_transmission_,  senddata->data);
+
+        last_transmission_ = now;
+        senddata->nextRetry = now + retryInterval;
+        this->before_write();
+        this->write_array(senddata->data);
+        this->flush();
+        this->after_write();
+      }
+      return true;
+    }
+
+    void Samsung_AC::before_write()
+    {
+      if (this->flow_control_pin_ != nullptr) {
+        LOGD("switching flow_control_pin to write");
+        this->flow_control_pin_->digital_write(true);
+      }
+    }
+
+    void Samsung_AC::after_write()
+    {
+      if (this->flow_control_pin_ != nullptr) {
+        LOGD("switching flow_control_pin to read");
+        this->flow_control_pin_->digital_write(false);
       }
     }
 

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -8,6 +8,7 @@
 #include "esphome/components/uart/uart.h"
 #include "samsung_ac_device.h"
 #include "protocol.h"
+#include "log.h"
 #include "device_state_tracker.h"
 
 namespace esphome
@@ -16,6 +17,27 @@ namespace esphome
   {
     class NasaProtocol;
     class Samsung_AC_Device;
+
+    // time to wait since last wire activity before sending
+    const uint16_t silenceInterval = 100;
+
+    // minimum time before a retry attempt
+    const uint16_t retryInterval = 500;
+
+    // minimum number of retries, even beyond timeout
+    const uint8_t minRetries = 1;
+
+    // maximum time to wait before discarding command
+    const uint16_t sendTimeout = 4000;
+
+    struct OutgoingData
+    {
+      uint8_t id;
+      std::vector<uint8_t> data;
+      uint32_t nextRetry;
+      uint32_t timeout;
+      uint8_t retries;
+    };
 
     class Samsung_AC : public PollingComponent,
                        public uart::UARTDevice,
@@ -94,7 +116,9 @@ namespace esphome
         return millis();
       }
 
-      void publish_data(std::vector<uint8_t> &data);
+      void publish_data(uint8_t id, std::vector<uint8_t> &&data);
+
+      void ack_data(uint8_t id);
 
       void set_room_temperature(const std::string address, float value) override
       {
@@ -238,7 +262,13 @@ namespace esphome
       DeviceStateTracker<Mode> state_tracker_{1000};
       std::set<std::string> addresses_;
 
+      std::deque<OutgoingData> send_queue_;
       std::vector<uint8_t> data_;
+      bool read_data();
+      void before_write();
+      bool write_data();
+      void after_write();
+
       uint32_t last_transmission_ = 0;
       uint32_t last_protocol_update_ = 0;
 

--- a/components/samsung_ac/util.cpp
+++ b/components/samsung_ac/util.cpp
@@ -18,12 +18,18 @@ namespace esphome
 
         std::string bytes_to_hex(const std::vector<uint8_t> &data)
         {
+            return bytes_to_hex(data, 0, data.size());
+        }
+
+        std::string bytes_to_hex(const std::vector<uint8_t> &data, uint16_t start, uint16_t end)
+        {
+
             std::string str;
-            str.reserve(data.size() * 2); // Memory reservations are made to increase efficiency.
-            for (uint8_t byte : data)
+            str.reserve((end - start) * 2); // Memory reservations are made to increase efficiency.
+            for (int i = start; i < end; i++)
             {
                 char buf[3];
-                snprintf(buf, sizeof(buf), "%02x", byte);
+                snprintf(buf, sizeof(buf), "%02x", data[i]);
                 str += buf;
             }
             return str;

--- a/components/samsung_ac/util.h
+++ b/components/samsung_ac/util.h
@@ -15,6 +15,7 @@ namespace esphome
 
         std::string long_to_hex(long number);
         int hex_to_int(const std::string &hex);
+        std::string bytes_to_hex(const std::vector<uint8_t> &data, uint16_t start, uint16_t end);
         std::string bytes_to_hex(const std::vector<uint8_t> &data);
         std::vector<uint8_t> hex_to_bytes(const std::string &hex);
         void print_bits_8(uint8_t value);


### PR DESCRIPTION
## **This is the work of @atanasenko**

## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [x] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->

- Queue outgoing packets and send them during loop()
- Only send packets during relatively quiet time
- Do not send new packets until we receive an ack for the one already sent
- Retry sending packet if no ack received
- Make absolutely sure that there is no incoming data available or there is no more data expected to arrive before sending
- Attempt to recover packets from incoming data if stars aligned in a way that all of the above failed
- Modify logging to be able to easily change log levels during development
- Optimize passing data buffers back and forth to prevent extra copies
- Group consequent NASA requests

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: https://github.com/omerfaruk-aran/esphome_samsung_hvac_bus/issues/57, https://github.com/omerfaruk-aran/esphome_samsung_hvac_bus/issues/229
Related: https://github.com/omerfaruk-aran/esphome_samsung_hvac_bus/pull/93 https://github.com/omerfaruk-aran/esphome_samsung_hvac_bus/pull/293

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.11.4
- **Home Assistant Version**: 2025.12.0

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: (e.g., AR09TXFCAWKNEU)
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: (e.g., M5STACK ATOM Lite + M5STACK RS-485)
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
The code was tested on ESPHome 2025.11.4 in my NASA-based system, and it performed its job perfectly.

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
```
