### PR TITLE
[NonNASA] Implement swing mode control

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -194,6 +194,7 @@ namespace esphome
             NonNasaFanspeed fanspeed = NonNasaFanspeed::Auto;
             NonNasaMode mode = NonNasaMode::Heat;
             bool power = false;
+            NonNasaWindDirection wind_direction = NonNasaWindDirection::Stop;
 
             std::vector<uint8_t> encode();
             std::string to_string();
@@ -213,6 +214,9 @@ namespace esphome
         extern std::list<NonNasaRequestQueueItem> nonnasa_requests;
         extern bool controller_registered;
         extern bool indoor_unit_awake;
+
+        NonNasaWindDirection swingmode_to_wind_direction(SwingMode swing);
+        uint8_t encode_request_wind_direction(NonNasaWindDirection wind_dir);
 
         DecodeResult try_decode_non_nasa_packet(std::vector<uint8_t> &data);
         void process_non_nasa_packet(MessageTarget *target);


### PR DESCRIPTION
## 📄 Description

Implements swing mode control for non-NASA devices. 

**NOTE:** 
`non_nasa_keepalive: true` must be disabled for any of the `Cmd20` control messages to come through. I think there's a bug in current keep-alive implementation which causes bus congestion and `Cmd20` are dropped.

### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [ ] 🐞 Bug Fix
- [x] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. Implement swing mode (vertical, horizontal, four-way) control for non-NASA protocol

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: 
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [x] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.12.4
- **Home Assistant Version**: 2025.12.5

### 🧩 Devices
- **Air Conditioner Type**:
  - [ ] NASA
  - [x] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AR12HSSDPWKN
- **Outdoor Unit Model**: -
- **ESP Device Model**: M5STACK ATOM S3 Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. Chaging swing mode in HomeAssitant should work

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->
```
[18:19:16.094][D][samsung_ac:712]: RECV: {src:00;dst:c8;cmd:20;command20:{target_temp:23; room_temp:26; pipe_in:27; pipe_out:28; power:1; wind_direction:28; fanspeed:0; mode:01}}
[18:19:16.098][D][samsung_ac:729]: Cmd20 received: src=00, wind_direction=28, target_temp=23, power=1, mode=1, fanspeed=0
[18:19:16.104][D][sensor:135]: 'Home EVA In temperature': Sending state 27.00000 °C with 1 decimals of accuracy
[18:19:16.106][D][sensor:135]: 'Home EVA Out temperature': Sending state 28.00000 °C with 1 decimals of accuracy
[18:19:16.113][D][number:034]: 'Home target temperature': Sending state 23.000000
[18:19:16.114][D][climate:426]: 'Home climate' - Sending state:
[18:19:16.122][D][climate:429]:   Mode: HEAT
[18:19:16.123][D][climate:434]:   Fan Mode: AUTO
[18:19:16.123][D][climate:440]:   Preset: NONE
[18:19:16.126][D][climate:446]:   Swing Mode: BOTH
[18:19:16.130][D][climate:449]:   Current Temperature: 24.60°C
[18:19:16.132][D][climate:456]:   Target Temperature: 23.00°C
```
---

## 🛠️ **YAML Configuration**

### Make sure non-NASA keepalive is disabled as it prevents Cmd20 (mode, fan, swing control) messages coming though
```yaml
#non_nasa_keepalive: true
```

### Add capabilities for vertical and horizontal swing modes
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
  capabilities: 
    vertical_swing: true
    horizontal_swing: true
```
