### PR TITLE
Handle non-NASA temperatures reported in Fahrenheit

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -37,12 +37,30 @@ namespace esphome
             Stop = 31
         };
 
+        enum class TemperatureUnit : uint8_t
+        {
+            Celsius,
+            Fahrenheit
+        };
+
+        struct Temperature
+        {
+            TemperatureUnit unit;
+            uint8_t temperature;
+
+            static Temperature decode(uint8_t data);
+            uint8_t encode();
+            std::string to_string();
+            float to_celsius();
+            void set_from_celsius(float celsius);
+        };
+
         struct NonNasaCommand20 // from indoor units
         {
-            uint8_t target_temp = 0;
-            uint8_t room_temp = 0;
-            uint8_t pipe_in = 0;
-            uint8_t pipe_out = 0;
+            Temperature target_temp = { TemperatureUnit::Celsius, 0 };
+            Temperature room_temp = { TemperatureUnit::Celsius, 0 };
+            Temperature pipe_in = { TemperatureUnit::Celsius, 0 };
+            Temperature pipe_out = { TemperatureUnit::Celsius, 0 };
 
             NonNasaFanspeed fanspeed = NonNasaFanspeed::Auto;
             NonNasaMode mode = NonNasaMode::Heat;
@@ -60,16 +78,16 @@ namespace esphome
             bool outdoor_unit_hot_gas_bypass = false;
             bool outdoor_unit_compressor = false;
             bool outdoor_unit_ac_fan = false;
-            uint8_t outdoor_unit_outdoor_temp_c = 0;
-            uint8_t outdoor_unit_discharge_temp_c = 0;
-            uint8_t outdoor_unit_condenser_mid_temp_c = 0;
+            Temperature outdoor_unit_outdoor_temp = { TemperatureUnit::Celsius, 0 };
+            Temperature outdoor_unit_discharge_temp = { TemperatureUnit::Celsius, 0 };
+            Temperature outdoor_unit_condenser_mid_temp = { TemperatureUnit::Celsius, 0 };
 
             std::string to_string();
         };
 
         struct NonNasaCommandC1 // from outdoor unit
         {
-            uint8_t outdoor_unit_sump_temp_c = 0;
+            Temperature outdoor_unit_sump_temp = { TemperatureUnit::Celsius, 0 };
 
             std::string to_string();
         };
@@ -189,8 +207,8 @@ namespace esphome
         {
             std::string dst;
 
-            uint8_t room_temp = 0;
-            uint8_t target_temp = 0;
+            Temperature target_temp = { TemperatureUnit::Celsius, 0 };
+            Temperature room_temp = { TemperatureUnit::Celsius, 0 };
             NonNasaFanspeed fanspeed = NonNasaFanspeed::Auto;
             NonNasaMode mode = NonNasaMode::Heat;
             bool power = false;


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

I discovered that temperatures weren't being read or set correctly for my unit while using this component.  Upon further investigation, I discovered that the non-NASA protocol can sometimes use Fahrenheit internally.

The way the non-NASA protocol actually reports temperatures is that the most significant bit is 0 for Celsius and 1 for Fahrenheit, and the rest of the bits indicate the temperature value.

The decoding portion here was actually discovered and implemented already in https://github.com/zegelin/samsung-hvac-mtqq/blob/803fc96e177efc3963e22d1172609b7eab33588b/src/protocol/commands.rs#L242-L266.

When writing temperatures, I was unable to find a way to discover what the expected temperature unit is, other than just by checking the unit of the last reported temperature.  From some reverse engineering, it also seems like the device expects 59 to be subtracted from Fahrenheit temperatures in the request. I was unable to find any documentation or prior art of this portion of the protocol other than reverse engineering my own system.

I was planning to implement & update tests for this commit, however it seems the non-NASA tests are quite broken -- they do not seem to compile and have many incorrect types.  It seems that they are unmaintained.  The functionality here is fairly simple / direct and it doesn't seem like tests would add too much value, it certainly doesn't seem worthwhile to distract from this PR by doing a bunch of test fixes for unrelated things.

### ✨ Key Changes
Handle Fahrenheit internal temperatures

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: 
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [ ] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 
- **Home Assistant Version**: 

### 🧩 Devices
- **Air Conditioner Type**:
  - [ ] NASA
  - [x] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: (e.g., AR09TXFCAWKNEU)
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: (e.g., M5STACK ATOM Lite + M5STACK RS-485)
- **Wiring Configuration**: (e.g., F1/F2)

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. manual

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
```
