### PR TITLE
Fix missing mqtt_client.h on ESP32 ESP-IDF (ESPHome 2026.2.0)

### DIFF
--- a/components/samsung_ac/debug_mqtt.cpp
+++ b/components/samsung_ac/debug_mqtt.cpp
@@ -3,94 +3,102 @@
 
 #if defined(USE_ESP8266)
 #include <AsyncMqttClient.h>
-AsyncMqttClient *mqtt_client{nullptr};
-#elif defined(USE_ESP32)
+static AsyncMqttClient *mqtt_client{nullptr};
+#endif
+
+#if defined(USE_ESP32) && defined(SAMSUNG_AC_DEBUG_MQTT)
 #include <mqtt_client.h>
-esp_mqtt_client_handle_t mqtt_client{nullptr};
+static esp_mqtt_client_handle_t mqtt_client{nullptr};
 #endif
 
 namespace esphome
 {
-    namespace samsung_ac
+namespace samsung_ac
+{
+    bool debug_mqtt_connected()
     {
-        bool debug_mqtt_connected()
-        {
-#if defined(USE_ESP8266) || defined(USE_ESP32)
-            if (mqtt_client == nullptr)
-                return false;
-
 #if defined(USE_ESP8266)
-            return mqtt_client->connected();
-#elif defined(USE_ESP32)
-            return true;
-#endif
+        if (mqtt_client == nullptr)
+            return false;
+        return mqtt_client->connected();
+
+#elif defined(USE_ESP32) && defined(SAMSUNG_AC_DEBUG_MQTT)
+        if (mqtt_client == nullptr)
+            return false;
+
+        return true;
+
 #else
         return false;
 #endif
-        }
+    }
 
-        void debug_mqtt_connect(const std::string &host, const uint16_t port, const std::string &username, const std::string &password)
-        {
-            if (host.empty())
-                return;
+    void debug_mqtt_connect(const std::string &host, const uint16_t port,
+                            const std::string &username, const std::string &password)
+    {
+        if (host.empty())
+            return;
 
 #if defined(USE_ESP8266)
-            if (mqtt_client == nullptr)
-            {
-                mqtt_client = new AsyncMqttClient();
-                mqtt_client->setServer(host.c_str(), port);
-                if (!username.empty())
-                    mqtt_client->setCredentials(username.c_str(), password.c_str());
-            }
+        if (mqtt_client == nullptr)
+        {
+            mqtt_client = new AsyncMqttClient();
+            mqtt_client->setServer(host.c_str(), port);
+            if (!username.empty())
+                mqtt_client->setCredentials(username.c_str(), password.c_str());
+        }
 
-            if (!mqtt_client->connected())
-                mqtt_client->connect();
+        if (!mqtt_client->connected())
+            mqtt_client->connect();
 
-#elif defined(USE_ESP32)
-            if (mqtt_client == nullptr)
-            {
+#elif defined(USE_ESP32) && defined(SAMSUNG_AC_DEBUG_MQTT)
+        if (mqtt_client == nullptr)
+        {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-                // For ESP-IDF v5.0 and above
-                std::string uri = "mqtt://" + host + ":" + std::to_string(port);
-                esp_mqtt_client_config_t mqtt_cfg = {};
-                mqtt_cfg.broker.address.uri = uri.c_str();
-                if (!username.empty())
-                {
-                    mqtt_cfg.credentials.username = username.c_str();
-                    mqtt_cfg.credentials.authentication.password = password.c_str();
-                }
-#else
-                // For ESP-IDF versions below v5.0
-                esp_mqtt_client_config_t mqtt_cfg = {};
-                mqtt_cfg.host = host.c_str();
-                mqtt_cfg.port = port;
-                if (!username.empty())
-                {
-                    mqtt_cfg.username = username.c_str();
-                    mqtt_cfg.password = password.c_str();
-                }
-#endif
-                mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
-                esp_mqtt_client_start(mqtt_client);
+            std::string uri = "mqtt://" + host + ":" + std::to_string(port);
+            esp_mqtt_client_config_t mqtt_cfg = {};
+            mqtt_cfg.broker.address.uri = uri.c_str();
+            if (!username.empty())
+            {
+                mqtt_cfg.credentials.username = username.c_str();
+                mqtt_cfg.credentials.authentication.password = password.c_str();
             }
-
+#else
+            esp_mqtt_client_config_t mqtt_cfg = {};
+            mqtt_cfg.host = host.c_str();
+            mqtt_cfg.port = port;
+            if (!username.empty())
+            {
+                mqtt_cfg.username = username.c_str();
+                mqtt_cfg.password = password.c_str();
+            }
 #endif
+            mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
+            esp_mqtt_client_start(mqtt_client);
         }
-
-        bool debug_mqtt_publish(const std::string &topic, const std::string &payload)
-        {
-#if defined(USE_ESP8266) || defined(USE_ESP32)
-            if (mqtt_client == nullptr)
-                return false;
-
-#if defined(USE_ESP8266)
-            return mqtt_client->publish(topic.c_str(), 0, false, payload.c_str()) != 0;
-#elif defined(USE_ESP32)
-            return esp_mqtt_client_publish(mqtt_client, topic.c_str(), payload.c_str(), payload.length(), 0, false) != -1;
+#else
+        (void)port;
+        (void)username;
+        (void)password;
 #endif
+    }
+
+    bool debug_mqtt_publish(const std::string &topic, const std::string &payload)
+    {
+#if defined(USE_ESP8266)
+        if (mqtt_client == nullptr)
+            return false;
+        return mqtt_client->publish(topic.c_str(), 0, false, payload.c_str()) != 0;
+
+#elif defined(USE_ESP32) && defined(SAMSUNG_AC_DEBUG_MQTT)
+        if (mqtt_client == nullptr)
+            return false;
+        return esp_mqtt_client_publish(mqtt_client, topic.c_str(), payload.c_str(),
+                                       payload.length(), 0, false) != -1;
 #else
         return false;
 #endif
-        }
-    } // namespace samsung_ac
+    }
+
+} // namespace samsung_ac
 } // namespace esphome


### PR DESCRIPTION
## 📄 Description

### What does this Pull Request do?
- [x] 🐞 Bug Fix

This PR fixes an ESP32 (ESP-IDF) build failure on ESPHome 2026.2.0 where `mqtt_client.h` was missing during compilation, causing the build to stop in `debug_mqtt.cpp`.

### ✨ Key Changes
1. Guard ESP32 MQTT debug implementation behind a compile-time flag (`SAMSUNG_AC_DEBUG_MQTT`) so `mqtt_client.h` is only included when debug MQTT is enabled.
2. Keep ESP32 behavior as a no-op when debug MQTT is not enabled (no host provided), preventing unnecessary dependency requirements.
3. Ensure debug MQTT remains functional when enabled by defining `SAMSUNG_AC_DEBUG_MQTT` and re-enabling ESP-IDF’s built-in `mqtt` component via `__init__.py`.

## 🔗 Related Issues
Fixes: #345 

---

## ✅ Checklist
- [x] Code compiles without errors 🧑‍💻
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (not required) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 Environment Information

### 🔢 Versions
- **ESPHome Version**: 2026.2.0

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other

---

## 🧪 Test Plan

### How were these changes tested?
1. Compiled with ESPHome 2026.2.0 + ESP32 ESP-IDF target to confirm the `mqtt_client.h` missing header error is resolved.
2. Verified that builds succeed when `debug_mqtt_host` is empty (default/no debug MQTT).
3. Verified that debug MQTT compiles when `debug_mqtt_host` is provided (enables IDF mqtt component).

### 🔍 Logs
- Previously failing:
  - `fatal error: mqtt_client.h: No such file or directory`
- Now compiling successfully on ESPHome 2026.2.0.

---